### PR TITLE
Adds support for Galaxy instance id setable through environmental var

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -15,6 +15,7 @@
       <param id="k8s_pull_policy" from_environ="GALAXY_RUNNERS_K8S_PULL_POLICY">IfNotPresent</param>
       <!-- Allows pods to retry up to this number of times, before marking the Job as failed -->
       <param id="k8s_pod_retrials" from_environ="GALAXY_RUNNERS_K8S_POD_RETRIALS">1</param>
+      <param id="k8s_galaxy_instance_id" from_environ="GALAXY_RUNNERS_K8S_INSTANCE_ID">my-instance</param>
     </plugin>
   </plugins>
   <handlers default="handlers">


### PR DESCRIPTION
While the Galaxy Kubernetes runner on Galaxy 18.05 supports setting the instance id, this Galaxy container didn't include the needed entry on the job_conf.xml