### PR TITLE
Changes for newest minikube/kubernetes

### DIFF
--- a/helm-configs/tertiary-portals-galaxy-18.05-minikube.yaml
+++ b/helm-configs/tertiary-portals-galaxy-18.05-minikube.yaml
@@ -39,6 +39,7 @@ job_conf:
 
 
 persistence:
+  storageClass: "-"
   minikube:
     hostPath: "/data/galaxy-18.05-tertiary"
 
@@ -58,3 +59,6 @@ postgresql:
 proftpd:
   service:
     type: NodePort
+
+rbac:
+  enabled: true


### PR DESCRIPTION
This PR adds some changes on the helm config file to address new defaults needed for current versions of minikube and Kubernetes.

- Sets StorageClass to "-" to avoid dynamic provision volumes on minikube.
- Sets rbac_enabled to true, otherwise jobs don't get dispatched on newer Kubernetes versions on minikube.