### PR TITLE
Changes setting to serve galaxy on / (chart 2.0.1)

### DIFF
--- a/helm-configs/tertiary-portals-galaxy-18.05-minikube.yaml
+++ b/helm-configs/tertiary-portals-galaxy-18.05-minikube.yaml
@@ -3,10 +3,10 @@
 # Settings for the init image
 init:
   image:
-    repository: pcm32/galaxy-sc-tertiary-init
-    tag: v18.05
+    repository: quay.io/ebigxa/galaxy-sc-tertiary
+    tag: develop
     pullPolicy: Always
-  force_copy: "__venv__,__config__,__galaxy-central__,__tools__"
+  force_copy: "__venv__,__config__,__galaxy-central__,__tools__,__welcome__"
 
 image:
   repository: pcm32/galaxy-web-k8s
@@ -24,7 +24,6 @@ galaxy_conf:
   admin_users: admin@email.co.uk
   allow_user_creation: true
   allow_user_deletion: true
-  filter-with: /galaxy
   cleanup_job: never
   enable_beta_mulled_containers: true
 
@@ -49,7 +48,6 @@ service:
 
 ingress:
   enabled: false
-  path: /galaxy
 
 
 postgresql:


### PR DESCRIPTION
Move to version 2.0.1 of Galaxy-stable helm chart, where galaxy is served on / instead of /galaxy.