### PR TITLE
Fix deployment travis to serve on / instead of /galaxy (as previous commit forgot travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - K8S_VERSION="v1.10.0"
     - MINIKUBE_VERSION="v0.28.2"
     - HELM_VERSION="v2.10.0-linux-amd64"
-    - HELM_REPO_VERSION="2.0.0"
+    - HELM_REPO_VERSION="2.0.1"
 
 before_script:
 - sudo mount --make-rshared /

--- a/helm-configs/.travis-galaxy-sc-deployment.yaml
+++ b/helm-configs/.travis-galaxy-sc-deployment.yaml
@@ -24,7 +24,6 @@ galaxy_conf:
   admin_users: admin@email.co.uk
   allow_user_creation: true
   allow_user_deletion: true
-  filter-with: /galaxy
   cleanup_job: never
   enable_beta_mulled_containers: true
 
@@ -50,7 +49,6 @@ service:
 
 ingress:
   enabled: false
-  path: /galaxy
 
 
 postgresql:


### PR DESCRIPTION
Travis was looking at /galaxy but should be looking in /. This requires changes in the travis used config and the helm chart version used.