### PR TITLE
Use single requirement (scanpy-scripts) for scanpy wrappers

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy_macros.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros.xml
@@ -34,7 +34,6 @@
   </token>
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="1.3.2">scanpy</requirement>
       <requirement type="package" version="0.0.3">scanpy-scripts</requirement>
       <yield/>
     </requirements>


### PR DESCRIPTION
This PR removes requirement on scanpy for scanpy wrappers, leaving scanpy-scripts the only requirement.