### PR TITLE
scanpy fix

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-filter-cells.py
+PYTHONIOENCODING=utf-8 scanpy-filter-cells.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -6,7 +6,7 @@
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
-ln -s '${input_obj_file}' input.h5 &&
+PYTHONIOENCODING=utf-8 ln -s '${input_obj_file}' input.h5 &&
 scanpy-filter-genes.py
     -i input.h5
     -f '${input_format}'

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -6,8 +6,8 @@
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
-PYTHONIOENCODING=utf-8 ln -s '${input_obj_file}' input.h5 &&
-scanpy-filter-genes.py
+ln -s '${input_obj_file}' input.h5 &&
+PYTHONIOENCODING=utf-8 scanpy-filter-genes.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-find-cluster.py
+PYTHONIOENCODING=utf-8 scanpy-find-cluster.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-find-markers.py
+PYTHONIOENCODING=utf-8 scanpy-find-markers.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-find-variable-genes.py -i input.h5
+PYTHONIOENCODING=utf-8 scanpy-find-variable-genes.py -i input.h5
     -f '${input_format}'
     -o output.h5
     -F '${output_format}'

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-neighbours.py
+PYTHONIOENCODING=utf-8 scanpy-neighbours.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-normalise-data.py
+PYTHONIOENCODING=utf-8 scanpy-normalise-data.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
@@ -9,7 +9,7 @@
 ln -s '${matrix}' matrix.mtx &&
 ln -s '${genes}' genes.tsv &&
 ln -s '${barcodes}' barcodes.tsv &&
-scanpy-read-10x.py
+PYTHONIOENCODING=utf-8 scanpy-read-10x.py
     -d ./
     -o read_10x.h5
     -F '${output_format}'

--- a/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-run-pca.py
+PYTHONIOENCODING=utf-8 scanpy-run-pca.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-run-tsne.py
+PYTHONIOENCODING=utf-8 scanpy-run-tsne.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-run-umap.py
+PYTHONIOENCODING=utf-8 scanpy-run-umap.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy-scale-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-scale-data.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-scanpy-scale-data.py
+PYTHONIOENCODING=utf-8 scanpy-scale-data.py
     -i input.h5
     -f '${input_format}'
     -o output.h5

--- a/tools/tertiary-analysis/scanpy/scanpy_macros.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">0.0.3</token>
+  <token name="@TOOL_VERSION@">1.3.2</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@PLOT_OPTS@">
 #if $do_plotting.plot
@@ -34,7 +34,7 @@
   </token>
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.0.3">scanpy-scripts</requirement>
+      <requirement type="package" version="0.0.4">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
This PR makes scanpy galaxy wrappers uses scanpy-scripts v0.0.4 (updated from v0.0.3) and make utf-8 characters in introspective messages printed by scanpy get printed.