### PR TITLE
Add wrapper to dropletutils-read-10x-counts.R

### DIFF
--- a/tools/tertiary-analysis/dropletutils/dropletutils-read-10x.xml
+++ b/tools/tertiary-analysis/dropletutils/dropletutils-read-10x.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tool id="dropletutils-read-10x" name="DropletUtils Read10x" version="@TOOL_VERSION@+galaxy0">
+  <description>into SingleCellExperiment object</description>
+  <macros>
+    <import>dropletutils_macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="exit_code"><![CDATA[
+ln -s '${matrix}' matrix.mtx &&
+ln -s '${genes}' genes.tsv &&
+ln -s '${barcodes}' barcodes.tsv &&
+dropletutils-read-10x-counts.R
+    -s .
+    -c TRUE
+    -o '${output_rds}'
+]]></command>
+
+  <inputs>
+    <param name="matrix" type="data" format="txt" label="Expression matrix in sparse matrix format (.mtx)"/>
+    <param name="genes" type="data" format="tsv" label="Gene table"/>
+    <param name="barcodes" type="data" format="tsv" label="Barcode/cell table"/>
+  </inputs>
+
+  <outputs>
+    <data name="output_rds" format="rdata" label="${tool.name} on ${on_string}: serialized SingleCellExperiment object"/>
+  </outputs>
+
+  <tests>
+    <test>
+      <param name="matrix" value="matrix.mtx"/>
+      <param name="genes" value="genes.tsv"/>
+      <param name="barcodes" value="barcodes.tsv"/>
+      <output name="output_rds" file="read_10x.rds" ftype="rdata" compare="sim_size"/>
+    </test>
+  </tests>
+
+  <help><![CDATA[
+=============================================================
+Read 10x-Genomics-formatted mtx directory (`Read10xCounts()`)
+=============================================================
+
+The mtx directory should contain:
+
+1) Raw expression quantification as a sparse matrix in Matrix Market format, where the each column is a gene and each row is a barcode/cell.
+
+2) A gene table of at least two columns where the first column gives the gene IDs.
+
+3) A barcode/cell table of at least one column giving the barcode/cell IDs.
+
+The above-mentioned files can be obtained by running `EBI SCXA Data Retrieval`
+with a dataset accession.
+
+
+@HELP@
+]]></help>
+  <expand macro="citations"/>
+</tool>

--- a/tools/tertiary-analysis/dropletutils/dropletutils_macros.xml
+++ b/tools/tertiary-analysis/dropletutils/dropletutils_macros.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<macros>
+
+  <token name="@TOOL_VERSION@">1.0.3</token>
+
+  <xml name="requirements">
+    <requirements>
+      <requirement type="package" version="0.0.1">dropletutils-scripts</requirement>
+    </requirements>
+  </xml>
+
+  <xml name="version">
+    <version_command><![CDATA[
+    echo $(R --version | grep version | grep -v GNU)", dropletutils version" $(R --vanilla --slave -e "library(DropletUtils); cat(sessionInfo()\$otherPkgs\$DropletUtils\$Version)" 2> /dev/null | grep -v -i "WARNING: ")
+    ]]></version_command>
+  </xml>
+
+  <xml name="citations">
+    <citations>
+      <citation type="doi">10.1101/234872</citation>
+    </citations>
+  </xml>
+</macros>


### PR DESCRIPTION
This PR adds a galaxy wrapper to dropletutils-read-10x-counts.R, which reads 10x data in mtx format into a SingleCellExperiment object that can be picked up by scater and other tools supporting SingleCellExperiment object. This is to reflect changes in function structure of scater and scater-scripts. As the object is relatively generic and dropletutils provides other nice functionalities (such as empty drop detection) which might be added later, I created a separate tool directory for this.