### PR TITLE
Missing seurat converter on tool conf and tool versions

### DIFF
--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -58,6 +58,7 @@
     <tool file="tertiary-analysis/seurat/seurat_find_clusters.xml"/>
     <tool file="tertiary-analysis/seurat/seurat_run_tsne.xml"/>
     <tool file="tertiary-analysis/seurat/seurat_find_markers.xml"/>
+    <tool file="tertiary-analysis/seurat/seurat_export_cellbrowser.xml"/>
   </section>
   <section name="DropletUtils" id="droputil-tools">
     <tool file="tertiary-analysis/dropletutils/dropletutils-read-10x.xml"/>

--- a/tools/tertiary-analysis/seurat/seurat_create_object.xml
+++ b/tools/tertiary-analysis/seurat/seurat_create_object.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_create_seurat_object" name="Seurat CreateSeuratObject" version="0.0.1">
+<tool id="seurat_create_seurat_object" name="Seurat CreateSeuratObject" version="2.3.1+galaxy0">
     <description>create a Seurat object</description>
     <macros>
         <import>seurat_macros.xml</import>
@@ -34,7 +34,7 @@ seurat-create-seurat-object.R
 Seurat_ is a toolkit for quality control, analysis, and exploration of single cell RNA sequencing data.
 It is developed and maintained by the `Satija Lab`_ at NYGC. Seurat aims to enable users to identify and
 interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse
-types of single cell data. 
+types of single cell data.
 
 This tool creates a Seurat object from an RDS object.
 

--- a/tools/tertiary-analysis/seurat/seurat_filter_cells.xml
+++ b/tools/tertiary-analysis/seurat/seurat_filter_cells.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_filter_cells" name="Seurat FilterCells" version="0.0.1">
+<tool id="seurat_filter_cells" name="Seurat FilterCells" version="2.3.1+galaxy0">
     <description>filter cells in a Seurat object</description>
     <macros>
         <import>seurat_macros.xml</import>
@@ -54,7 +54,7 @@ seurat-filter-cells.R
 Seurat_ is a toolkit for quality control, analysis, and exploration of single cell RNA sequencing data.
 It is developed and maintained by the `Satija Lab`_ at NYGC. Seurat aims to enable users to identify and
 interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse
-types of single cell data. 
+types of single cell data.
 
 This tool filters a Seurat RDS object.
 

--- a/tools/tertiary-analysis/seurat/seurat_find_clusters.xml
+++ b/tools/tertiary-analysis/seurat/seurat_find_clusters.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_find_clusters" name="Seurat FindClusters" version="0.0.1">
+<tool id="seurat_find_clusters" name="Seurat FindClusters" version="2.3.1+galaxy0">
     <description>find clusters of cells</description>
     <macros>
         <import>seurat_macros.xml</import>
@@ -37,7 +37,7 @@ seurat-find-clusters.R
 Seurat_ is a toolkit for quality control, analysis, and exploration of single cell RNA sequencing data.
 It is developed and maintained by the `Satija Lab`_ at NYGC. Seurat aims to enable users to identify and
 interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse
-types of single cell data. 
+types of single cell data.
 
 This tool find clusters in a Seurat object.
 

--- a/tools/tertiary-analysis/seurat/seurat_find_markers.xml
+++ b/tools/tertiary-analysis/seurat/seurat_find_markers.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_find_markers" name="Seurat FindMarkers" version="0.0.1">
+<tool id="seurat_find_markers" name="Seurat FindMarkers" version="2.3.1+galaxy0">
     <description>find markers (differentially expressed genes)</description>
     <macros>
         <import>seurat_macros.xml</import>
@@ -34,7 +34,7 @@ seurat-find-markers.R
 Seurat_ is a toolkit for quality control, analysis, and exploration of single cell RNA sequencing data.
 It is developed and maintained by the `Satija Lab`_ at NYGC. Seurat aims to enable users to identify and
 interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse
-types of single cell data. 
+types of single cell data.
 
 This tool finds markers (differentially expressed genes) for each of the identity classes in a dataset. It outputs a text file containing a ranked list of putative markers, and associated statistics (p-values, ROC score, etc.)
 

--- a/tools/tertiary-analysis/seurat/seurat_find_variable_genes.xml
+++ b/tools/tertiary-analysis/seurat/seurat_find_variable_genes.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_find_variable_genes" name="Seurat FindVariableGenes" version="0.0.1">
+<tool id="seurat_find_variable_genes" name="Seurat FindVariableGenes" version="2.3.1+galaxy0">
     <description>identify variable genes</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_normalise_data.xml
+++ b/tools/tertiary-analysis/seurat/seurat_normalise_data.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_normalise_data" name="Seurat NormaliseData" version="0.0.1">
+<tool id="seurat_normalise_data" name="Seurat NormaliseData" version="2.3.1+galaxy0">
     <description>normalise data</description>
     <macros>
         <import>seurat_macros.xml</import>
@@ -11,7 +11,7 @@ seurat-normalise-data.R
 --input-object-file '$input'
 #if $norm:
     --normalization-method $norm
-#end if 
+#end if
 #if $assay:
     --assay-type '$assay'
 #end if
@@ -48,7 +48,7 @@ seurat-normalise-data.R
 Seurat_ is a toolkit for quality control, analysis, and exploration of single cell RNA sequencing data.
 It is developed and maintained by the `Satija Lab`_ at NYGC. Seurat aims to enable users to identify and
 interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse
-types of single cell data. 
+types of single cell data.
 
 This tool normalises a Seurat RDS object.
 

--- a/tools/tertiary-analysis/seurat/seurat_read10x.xml
+++ b/tools/tertiary-analysis/seurat/seurat_read10x.xml
@@ -1,4 +1,4 @@
-<tool id="seurat-read10x" name="Seurat Read10x" version="0.1">
+<tool id="seurat-read10x" name="Seurat Read10x" version="2.3.1+galaxy0">
   <macros>
       <import>seurat_macros.xml</import>
   </macros>

--- a/tools/tertiary-analysis/seurat/seurat_run_pca.xml
+++ b/tools/tertiary-analysis/seurat/seurat_run_pca.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_run_pca" name="Seurat RunPCA" version="0.0.1">
+<tool id="seurat_run_pca" name="Seurat RunPCA" version="2.3.1+galaxy0">
     <description>run a PCA dimensionality reduction</description>
     <macros>
         <import>seurat_macros.xml</import>
@@ -44,7 +44,7 @@ seurat-run-pca.R
 Seurat_ is a toolkit for quality control, analysis, and exploration of single cell RNA sequencing data.
 It is developed and maintained by the `Satija Lab`_ at NYGC. Seurat aims to enable users to identify and
 interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse
-types of single cell data. 
+types of single cell data.
 
 This tool runs a PCA dimensionality reduction
 

--- a/tools/tertiary-analysis/seurat/seurat_run_tsne.xml
+++ b/tools/tertiary-analysis/seurat/seurat_run_tsne.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_run_tsne" name="Seurat RunTSNE" version="0.0.1">
+<tool id="seurat_run_tsne" name="Seurat RunTSNE" version="2.3.1+galaxy0">
     <description>run t-SNE dimensionality reduction</description>
     <macros>
         <import>seurat_macros.xml</import>
@@ -43,7 +43,7 @@ seurat-run-tsne.R
 Seurat_ is a toolkit for quality control, analysis, and exploration of single cell RNA sequencing data.
 It is developed and maintained by the `Satija Lab`_ at NYGC. Seurat aims to enable users to identify and
 interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse
-types of single cell data. 
+types of single cell data.
 
 This tool runs t-SNE dimensionality reduction on selected features.
 

--- a/tools/tertiary-analysis/seurat/seurat_scale_data.xml
+++ b/tools/tertiary-analysis/seurat/seurat_scale_data.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_scale_data" name="Seurat ScaleData" version="0.0.1">
+<tool id="seurat_scale_data" name="Seurat ScaleData" version="2.3.1+galaxy0">
     <description>scale and center genes</description>
     <macros>
         <import>seurat_macros.xml</import>
@@ -40,7 +40,7 @@ seurat-scale-data.R
 Seurat_ is a toolkit for quality control, analysis, and exploration of single cell RNA sequencing data.
 It is developed and maintained by the `Satija Lab`_ at NYGC. Seurat aims to enable users to identify and
 interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse
-types of single cell data. 
+types of single cell data.
 
 This tool regresses out variables in a Seurat object to mitigate the effect of confounding factors.
 


### PR DESCRIPTION
Adds missing entry on the tool conf for the converter (seurat2cellbrowser). Tidy ups the versions of seurat tools.