### PR TITLE
Use sc3-scripts v0.0.3

### DIFF
--- a/tools/tertiary-analysis/sc3/sc3-macros.xml
+++ b/tools/tertiary-analysis/sc3/sc3-macros.xml
@@ -3,7 +3,7 @@
   <token name="@HELP@">Documentation can be found at http://bioconductor.org/packages/release/bioc/vignettes/SC3/inst/doc/SC3.html</token>
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.0.2">bioconductor-sc3-scripts</requirement>
+      <requirement type="package" version="0.0.3">bioconductor-sc3-scripts</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
This PR makes sc3 galaxy wrappers call v0.0.3 of sc3-scripts which included a few useful fixes. Particularly this fixes an issue with calc-consensus due to interface change of sc3-scripts after v0.0.2.