### PR TITLE
GTF to genelist

### DIFF
--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -96,4 +96,7 @@
   <section name="UCSC Cell Browser" id="cell-browser">
     <tool file="tertiary-analysis/ucsc-cell-browser/cell-browser.xml"  labels="Viz"/>
   </section>
+  <section name="Util" id="utilities">
+    <tool file="util/gtf2gene_list.xml"/>
+  </section>
 </toolbox>

--- a/tools/util/gtf2gene.R
+++ b/tools/util/gtf2gene.R
@@ -1,0 +1,8 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages(require(rtracklayer))
+args <- commandArgs(TRUE)
+
+annotation <- elementMetadata(import( args[1] ))
+genes <- unique(annotation[['gene_id']])
+writeLines(genes[ ! is.na(genes)], con = 'genes.txt')

--- a/tools/util/gtf2gene_list.xml
+++ b/tools/util/gtf2gene_list.xml
@@ -1,0 +1,35 @@
+<tool id="_ensembl_gtf2gene_list" name="E! GTF2GeneList" version="1.42.1+galaxy0">
+    <description>extracts gene ids from Ensembl GTF using rtracklayer</description>
+    <requirements>
+      <requirement type="package" version="1.42.1">bioconductor-rtracklayer</requirement>
+      <yield/>
+    </requirements> 
+    <command detect_errors="exit_code"><![CDATA[
+       ln -s '$gtf_input' input.gtf;
+       Rscript $__tool_directory__/gtf2gene.R input.gtf 
+	    ]]></command>
+
+    <inputs>
+        <param name="gtf_input" type="data" format="gff" label="E! GTF file" />
+    </inputs>
+
+    <outputs>
+        <data name="gene_list" format="txt" from_work_dir="genes.txt" label="${tool.name} on ${on_string}"/>
+    </outputs>
+
+    <help><![CDATA[
+.. class:: infomark
+
+**What it does**
+
+**Inputs**
+
+    * Ensembl GTF file 
+
+-----
+
+**Outputs**
+
+    * Gene identifier list 
+]]></help>
+</tool>

--- a/tools/util/gtf2gene_list.xml
+++ b/tools/util/gtf2gene_list.xml
@@ -2,7 +2,6 @@
     <description>extracts gene ids from Ensembl GTF using rtracklayer</description>
     <requirements>
       <requirement type="package" version="1.42.1">bioconductor-rtracklayer</requirement>
-      <yield/>
     </requirements> 
     <command detect_errors="exit_code"><![CDATA[
        ln -s '$gtf_input' input.gtf;

--- a/tools/util/gtf2gene_list.xml
+++ b/tools/util/gtf2gene_list.xml
@@ -1,4 +1,4 @@
-<tool id="_ensembl_gtf2gene_list" name="E! GTF2GeneList" version="1.42.1+galaxy0">
+<tool id="_ensembl_gtf2gene_list" name="GTF2GeneList" version="1.42.1+galaxy0">
     <description>extracts gene ids from Ensembl GTF using rtracklayer</description>
     <requirements>
       <requirement type="package" version="1.42.1">bioconductor-rtracklayer</requirement>
@@ -10,17 +10,19 @@
 	    ]]></command>
 
     <inputs>
-        <param name="gtf_input" type="data" format="gff" label="E! GTF file" />
+        <param name="gtf_input" type="data" format="gff" label="Ensembl GTF file" />
     </inputs>
 
     <outputs>
-        <data name="gene_list" format="txt" from_work_dir="genes.txt" label="${tool.name} on ${on_string}"/>
+        <data name="gene_list" format="tsv" from_work_dir="genes.txt" label="${tool.name} on ${on_string}"/>
     </outputs>
 
     <help><![CDATA[
 .. class:: infomark
 
 **What it does**
+
+Given an Ensembl GTF file, it will extract the list of all gene identifiers in the GTF to a simple tsv file.
 
 **Inputs**
 
@@ -30,6 +32,6 @@
 
 **Outputs**
 
-    * Gene identifier list 
+    * Gene identifier list in tsv.
 ]]></help>
 </tool>


### PR DESCRIPTION
adds a utility snippet to transform a GTF file to a list of gene identifiers.