### PR TITLE
Fix default values for filter-cells/genes. Bump version requirement.

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
@@ -33,7 +33,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-cells.py
         <option value="n_genes">n_genes</option>
         <option value="n_counts">n_counts</option>
       </param>
-      <param name="min" type="float" value="-1e9" label="Min value"/>
+      <param name="min" type="float" value="0" min="0" label="Min value"/>
       <param name="max" type="float" value="1e9" label="Max value"/>
     </repeat>
     <param name="subset" argument="--subset-list" type="data" format="tsv" optional="true" label="List of barcodes"/>
@@ -55,7 +55,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-cells.py
       </repeat>
       <repeat name="parameters">
         <param name="name" value="n_counts"/>
-        <param name="min" value="-1e9"/>
+        <param name="min" value="0"/>
         <param name="max" value="1e9"/>
       </repeat>
       <output name="output_h5" file="filter_cells.h5" ftype="h5" compare="sim_size"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -33,7 +33,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-genes.py
         <option value="n_cells">n_cells</option>
         <option value="n_counts">n_counts</option>
       </param>
-      <param name="min" type="float" value="-1e9" label="Min value"/>
+      <param name="min" type="float" value="0" min="0" label="Min value"/>
       <param name="max" type="float" value="1e9" label="Max value"/>
     </repeat>
     <param name="subset" argument="--subset-list" type="data" format="tsv" optional="true" label="List of gene IDs or symbols"/>
@@ -55,7 +55,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-genes.py
       </repeat>
       <repeat name="parameters">
         <param name="name" value="n_counts"/>
-        <param name="min" value="-1e9"/>
+        <param name="min" value="0"/>
         <param name="max" value="1e9"/>
       </repeat>
       <output name="output_h5" file="filter_genes.h5" ftype="h5" compare="sim_size"/>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros.xml
@@ -34,7 +34,7 @@
   </token>
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.0.4">scanpy-scripts</requirement>
+      <requirement type="package" version="0.0.5">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
This PR fixes negative default values for filter-cells and filter-genes, and bumps required scanpy-scripts version to 0.0.5.