### PR TITLE
Use dynamic-k8s-dispatcher to use resource sliders

### DIFF
--- a/config/job_conf.xml
+++ b/config/job_conf.xml
@@ -46,9 +46,11 @@
       <param id="docker_volumes" from_environ="GALAXY_DOCKER_VOLUMES">$defaults</param>
       <param id="docker_default_container_id" from_environ="GALAXY_DOCKER_DEFAULT_CONTAINER">busybox:ubuntu-14.04</param>
     </destination>
-    <destination id="dynamic-k8s" runner="dynamic">
+    <destination id="dynamic-k8s-dispatcher" runner="dynamic">
       <param id="type">python</param>
-      <param id="function">k8s_wrapper</param>
+      <param id="function">k8s_dispatcher</param>
+      <param id="no_docker_default_destination_id" from_environ="GALAXY_DESTINATIONS_NO_DOCKER_DEFAULT">slurm_cluster</param>
+      <param id="docker_default_container_id" from_environ="GALAXY_DOCKER_DEFAULT_CONTAINER">busybox:ubuntu-14.04</param>
       <param id="docker_enabled">true</param>
     </destination>
     <destination id="dynamic-k8s-tiny" runner="dynamic">

--- a/helm-configs/tertiary-portals-galaxy-18.05-minikube.yaml
+++ b/helm-configs/tertiary-portals-galaxy-18.05-minikube.yaml
@@ -33,8 +33,7 @@ job_conf:
     enable_local: "true"
     enable_k8: "true"
   destinations:
-    default: "docker_dispatch"
-    docker_default: "k8s_default"
+    default: "dynamic-k8s-dispatcher"
     no_docker_default: "local_no_container"
 
 

--- a/rules/k8s_destinations.py
+++ b/rules/k8s_destinations.py
@@ -40,8 +40,11 @@ __xlarge = {'requests_cpu': 4,
 
 __path_tool2container = "config/phenomenal_tools2container.yaml"
 
-def k8s_wrapper(resource_params):
+def k8s_dispatcher(resource_params, rule_helper, no_docker_default_destination_id, tool):
     # Allocate extra time
+    if not rule_helper.supports_docker(tool):
+        #return JobDestination(id=no_docker_default_destination_id, params=resource_params)
+        return no_docker_default_destination_id
     resource_params['docker_enabled'] = True
     return JobDestination(runner="k8s", params=resource_params)
 


### PR DESCRIPTION
This switches to a dynamic destination that can make use of the resource sliders (for container based jobs). Jobs that are not container enabled (uploads) run on the galaxy container still.