### PR TITLE
Expose 10x output filtering

### DIFF
--- a/tools/tertiary-analysis/scanpy/.shed.yml
+++ b/tools/tertiary-analysis/scanpy/.shed.yml
@@ -1,5 +1,5 @@
 name: scanpy_scripts
-owner: ebi-gxa 
+owner: ebi-gxa
 description: "scanpy-scripts, command-line wrapper scripts around Scanpy."
 long_description: |
     Scanpy is a scalable toolkit for analyzing single-cell gene expression data.  It includes
@@ -7,7 +7,7 @@ long_description: |
     expression testing. Scanpy-scripts provides a set of command-line wrapper scripts that are
     composed from Scanpy API for easy execution of common analysis.
 homepage_url: https://scanpy.readthedocs.io
-remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/scanpy-scripts
+remote_repository_url: https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/tree/develop/tools/tertiary-analysis/scanpy
 type: unrestricted
 categories:
 - Transcriptomics

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_filter_genes" name="Scanpy FilterGenes" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_filter_genes" name="Scanpy FilterGenes" version="@TOOL_VERSION@+galaxy1">
   <description>based on counts and numbers of cells expressed</description>
   <macros>
     <import>scanpy_macros.xml</import>
@@ -23,6 +23,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-genes.py
     #if $subset
         -s '${subset}'
     #end if
+    @EXPORT_MTX_OPTS@
 ]]></command>
 
   <inputs>
@@ -37,10 +38,12 @@ PYTHONIOENCODING=utf-8 scanpy-filter-genes.py
       <param name="max" type="float" value="1e9" label="Max value"/>
     </repeat>
     <param name="subset" argument="--subset-list" type="data" format="tsv" optional="true" label="List of gene IDs or symbols"/>
+    <expand macro="export_mtx_params"/>
   </inputs>
 
   <outputs>
     <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Filtered genes"/>
+    <expand macro="export_mtx_outputs"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
@@ -16,9 +16,7 @@ PYTHONIOENCODING=utf-8 scanpy-normalise-data.py
     #if $save_raw
         '${save_raw}'
     #end if
-    #if $export_mtx
-        '${export_mtx}' ./
-    #end if
+    @EXPORT_MTX_OPTS@
 ]]></command>
 
   <inputs>
@@ -26,20 +24,12 @@ PYTHONIOENCODING=utf-8 scanpy-normalise-data.py
     <expand macro="output_object_params"/>
     <param name="scale_factor" argument="--scale-factor" type="float" value="1e4" label="Target number to normalise to" help="Aimed counts per cell after normalisation, default: 1e4"/>
     <param name="save_raw" argument="--save-raw" type="boolean" truevalue="--save-raw" falsevalue="" checked="true" label="Save pre-normalised data" help="Save raw quantification in log scale before normalisation."/>
-    <param name="export_mtx" argument="--export-mtx" type="boolean" truevalue="--export-mtx" falsevalue="" checked="false" label="Save normalised data to 10x format" help="If enabled, it will generate in addition to the main output in Loom or AnnData an export in 10x format of the normalised data."/>
+    <expand macro="export_mtx_params"/>
   </inputs>
 
   <outputs>
     <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Normalized data" />
-    <data name="matrix_10x" format="txt" from_work_dir="matrix.mtx" label="${tool.name} on ${on_string}: 10x matrix">
-      <filter>export_mtx</filter>
-    </data>
-    <data name="genes_10x" format="tsv" from_work_dir="genes.tsv" label="${tool.name} on ${on_string}: 10x genes">
-      <filter>export_mtx</filter>
-    </data>
-    <data name="barcodes_10x" format="tsv" from_work_dir="barcodes.tsv" label="${tool.name} on ${on_string}: 10x barcodes">
-      <filter>export_mtx</filter>
-    </data>
+    <expand macro="export_mtx_outputs"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_normalise_data" name="Scanpy NormaliseData" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_normalise_data" name="Scanpy NormaliseData" version="@TOOL_VERSION@+galaxy1">
   <description>to make all cells having the same total expression</description>
   <macros>
     <import>scanpy_macros.xml</import>
@@ -16,17 +16,30 @@ PYTHONIOENCODING=utf-8 scanpy-normalise-data.py
     #if $save_raw
         '${save_raw}'
     #end if
+    #if $export_mtx
+        '${export_mtx}' ./
+    #end if
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
-    <param name="scale_factor" argument="--scale-factor" type="float" value="1e4" label="Target number to normalise to"/>
-    <param name="save_raw" argument="--save-raw" type="boolean" truevalue="--save-raw" falsevalue="" checked="true" label="Save pre-normalised data"/>
+    <param name="scale_factor" argument="--scale-factor" type="float" value="1e4" label="Target number to normalise to" help="Aimed counts per cell after normalisation, default: 1e4"/>
+    <param name="save_raw" argument="--save-raw" type="boolean" truevalue="--save-raw" falsevalue="" checked="true" label="Save pre-normalised data" help="Save raw quantification in log scale before normalisation."/>
+    <param name="export_mtx" argument="--export-mtx" type="boolean" truevalue="--export-mtx" falsevalue="" checked="false" label="Save normalised data to 10x format" help="If enabled, it will generate in addition to the main output in Loom or AnnData an export in 10x format of the normalised data."/>
   </inputs>
 
   <outputs>
     <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Normalized data" />
+    <data name="matrix_10x" format="txt" from_work_dir="matrix.mtx" label="${tool.name} on ${on_string}: 10x matrix">
+      <filter>export_mtx</filter>
+    </data>
+    <data name="genes_10x" format="tsv" from_work_dir="genes.tsv" label="${tool.name} on ${on_string}: 10x genes">
+      <filter>export_mtx</filter>
+    </data>
+    <data name="barcodes_10x" format="tsv" from_work_dir="barcodes.tsv" label="${tool.name} on ${on_string}: 10x barcodes">
+      <filter>export_mtx</filter>
+    </data>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros.xml
@@ -38,10 +38,13 @@
       <yield/>
     </requirements>
   </xml>
+  <token name="@EXPORT_MTX_OPTS@">
+      ${export_mtx}
+  </token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
 
-1.3.2+galaxy1: Normalise-data: Exposes ability to output 10x files.
+1.3.2+galaxy1: Normalise-data and filter-genes: Exposes ability to output 10x files.
 
 1.3.2+galaxy0: Initial contribution. Ni Huang and Pablo Moreno, Expression Atlas team https://www.ebi.ac.uk/gxa/home  at
 EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
@@ -88,5 +91,19 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
     <param name="arrows" argument="--arrows" type="boolean" checked="false" label="Show arrows"/>
     <param name="sort_order" argument="--no-sort-order" type="boolean" checked="true" label="Element with high color-by value plot on top"/>
     <param name="frameoff" argument="--frameoff" type="boolean" checked="false" label="Omit frame"/>
+  </xml>
+  <xml name="export_mtx_params">
+    <param name="export_mtx" argument="--export-mtx" type="boolean" truevalue="--export-mtx ./" falsevalue="" checked="false" label="Save normalised data to 10x format" help="If enabled, it will generate in addition to the main output in Loom or AnnData an export in 10x format of the normalised data."/>
+  </xml>
+  <xml name="export_mtx_outputs">
+    <data name="matrix_10x" format="txt" from_work_dir="matrix.mtx" label="${tool.name} on ${on_string}: 10x matrix">
+      <filter>export_mtx</filter>
+    </data>
+    <data name="genes_10x" format="tsv" from_work_dir="genes.tsv" label="${tool.name} on ${on_string}: 10x genes">
+      <filter>export_mtx</filter>
+    </data>
+    <data name="barcodes_10x" format="tsv" from_work_dir="barcodes.tsv" label="${tool.name} on ${on_string}: 10x barcodes">
+      <filter>export_mtx</filter>
+    </data>
   </xml>
 </macros>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros.xml
@@ -41,6 +41,8 @@
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
 
+1.3.2+galaxy1: Normalise-data: Exposes ability to output 10x files.
+
 1.3.2+galaxy0: Initial contribution. Ni Huang and Pablo Moreno, Expression Atlas team https://www.ebi.ac.uk/gxa/home  at
 EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
     ]]></token>


### PR DESCRIPTION
This exposes the 10x optional output from the scanpy normalise data step. It also fixes an incorrect URL for the toolshed for scanpy suite.