### PR TITLE
Install socat on travis to fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 
 before_script:
 - sudo mount --make-rshared /
+- sudo apt-get install -y socat
 # Download kubectl, which is a requirement for using minikube.
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 # Download minikube.


### PR DESCRIPTION
For some reason travis VMs don't seem to have socat anymore, making helm fail in the tests.