### PR TITLE
Feature/scanpy update

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
@@ -2,41 +2,57 @@
 <tool id="scanpy_filter_cells" name="Scanpy FilterCells" version="@TOOL_VERSION@+galaxy0">
   <description>based on counts and numbers of genes expressed</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-filter-cells.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    #if $parameters
-        #set pars = ','.join([str($p['name']) for $p in $parameters])
-        -p '${pars}'
-        #set mins = ','.join([str($p['min']) for $p in $parameters])
-        -l '${mins}'
-        #set maxs = ','.join([str($p['max']) for $p in $parameters])
-        -j '${maxs}'
-    #end if
-    #if $subset
-        -s '${subset}'
-    #end if
+PYTHONIOENCODING=utf-8 scanpy-filter-cells
+#if $gene_name
+    --gene-name '${gene_name}'
+#end if
+#if $parameters
+    #set pars = ' '.join(['--param {name} {min} {max}'.format(**$p) for $p in $parameters])
+    ${pars}
+#end if
+#if $categories
+    #set cats = ' '.join(['--category {name} {values}'.format(**$c) for $c in $categories])
+    ${cats}
+#end if
+#if $subsets
+    #set subs = ' '.join(['--subsets {name} {subset}'.format(**$s) for $c in $subsets])
+    ${subs}
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
     ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
+
+    <param name="gene_name" type="text" value="index" label="Name of the column in `anndata.var` that contains gene name"
+           help="This is used for flagging mitochondria genes"/>
+
     <repeat name="parameters" title="Parameters used to filter cells" min="1">
       <param name="name" type="text" value="n_genes" label="Name of parameter to filter on" help="for example n_genes or n_counts">
         <option value="n_genes">n_genes</option>
-        <option value="n_counts">n_counts</option>
+        <option value="cell:n_counts">n_counts</option>
+        <option value="pct_counts_mito">pct_counts_mito</option>
       </param>
       <param name="min" type="float" value="0" min="0" label="Min value"/>
       <param name="max" type="float" value="1e9" label="Max value"/>
     </repeat>
-    <param name="subset" argument="--subset-list" type="data" format="tsv" optional="true" label="List of barcodes"/>
+
+    <repeat name="categories" title="Categories used to filter cells" min="0">
+      <param name="name" type="text" value="" label="Name of the categorical variable to filter on"/>
+      <param name="values" type="text" value="" label="Comma-separated values"/>
+    </repeat>
+
+    <repeat name="subsets" title="Subsets used to filter cells" min="0">
+      <param name="name" type="text" value="" label="Name of the categorical variable to filter on"/>
+      <param name="subset" type="data" format="tabular" label="List of values"/>
+    </repeat>
   </inputs>
 
   <outputs>
@@ -58,7 +74,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-cells.py
         <param name="min" value="0"/>
         <param name="max" value="1e9"/>
       </repeat>
-      <output name="output_h5" file="filter_cells.h5" ftype="h5" compare="sim_size"/>
+      <output name="output_h5" file="output.h5" ftype="h5" compare="sim_size"/>
     </test>
   </tests>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
@@ -32,7 +32,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-cells
     <expand macro="output_object_params"/>
 
     <param name="gene_name" type="text" value="index" label="Name of the column in `anndata.var` that contains gene name"
-           help="This is used for flagging mitochondria genes"/>
+           help="This is used for flagging mitochondria genes (starting with 'MT-')"/>
 
     <repeat name="parameters" title="Parameters used to filter cells" min="1">
       <param name="name" type="text" value="n_genes" label="Name of parameter to filter on" help="for example n_genes or n_counts">
@@ -53,10 +53,12 @@ PYTHONIOENCODING=utf-8 scanpy-filter-cells
       <param name="name" type="text" value="" label="Name of the categorical variable to filter on"/>
       <param name="subset" type="data" format="tabular" label="List of values"/>
     </repeat>
+    <expand macro="export_mtx_params"/>
   </inputs>
 
   <outputs>
     <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Filtered cells"/>
+    <expand macro="export_mtx_outputs"/>
   </outputs>
 
   <tests>
@@ -70,7 +72,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-cells
         <param name="max" value="2500"/>
       </repeat>
       <repeat name="parameters">
-        <param name="name" value="n_counts"/>
+        <param name="name" value="cell:n_counts"/>
         <param name="min" value="0"/>
         <param name="max" value="1e9"/>
       </repeat>

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
@@ -79,13 +79,14 @@ PYTHONIOENCODING=utf-8 scanpy-filter-cells
   </tests>
 
   <help><![CDATA[
-========================================================================================
-Filter cells outliers based on counts and numbers of genes expressed (`pp.filter_cells`)
-========================================================================================
+===================================================================
+Filter cells based on various QC metrics (`scanpy.pp.filter_cells`)
+===================================================================
 
-For instance, only keep cells with at least `min_counts` counts or
-`min_genes` genes expressed. This is to filter measurement outliers, i.e.,
-"unreliable" observations.
+For instance, only keep cells with at least `min_counts` and at most
+`max_counts` UMI and/or at least `min_genes` expressed genes and/or at most
+`max_mito_percent` mitocondria expression. This is to filter measurement
+outliers, i.e., "unreliable" observations.
 
 @HELP@
 

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -2,42 +2,50 @@
 <tool id="scanpy_filter_genes" name="Scanpy FilterGenes" version="@TOOL_VERSION@+galaxy1">
   <description>based on counts and numbers of cells expressed</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-filter-genes.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    #if $parameters
-    #set pars = ','.join([str($p['name']) for $p in $parameters])
-        -p '${pars}'
-    #set mins = ','.join([str($p['min']) for $p in $parameters])
-        -l '${mins}'
-    #set maxs = ','.join([str($p['max']) for $p in $parameters])
-        -j '${maxs}'
-    #end if
-    #if $subset
-        -s '${subset}'
-    #end if
-    @EXPORT_MTX_OPTS@
+PYTHONIOENCODING=utf-8 scanpy-filter-genes
+#if $parameters
+    #set pars = ' '.join(['--param {name} {min} {max}'.format(**$p) for $p in $parameters])
+    ${pars}
+#end if
+#if $categories
+    #set cats = ' '.join(['--category {name} {values}'.format(**$c) for $c in $categories])
+    ${cats}
+#end if
+#if $subsets
+    #set subs = ' '.join(['--subsets {name} {subset}'.format(**$s) for $c in $subsets])
+    ${subs}
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
-    <repeat name="parameters" title="Parameters used to filter genes" min="1">
-      <param name="name" type="text" value="n_cells" label="Name of parameter to filter on" help="for example n_cells or n_counts">
+
+    <repeat name="parameters" title="Parameters used to filter cells" min="1">
+      <param name="name" type="text" value="n_cells" label="Name of parameter to filter on" help="for example n_genes or n_counts">
         <option value="n_cells">n_cells</option>
-        <option value="n_counts">n_counts</option>
+        <option value="gene:n_counts">n_counts</option>
       </param>
-      <param name="min" type="float" value="0" min="0" label="Min value"/>
-      <param name="max" type="float" value="1e9" label="Max value"/>
+      <param name="min" type="float" min="0" value="0" label="Min value"/>
+      <param name="max" type="float" min="0" value="1e9" label="Max value"/>
     </repeat>
-    <param name="subset" argument="--subset-list" type="data" format="tsv" optional="true" label="List of gene IDs or symbols"/>
+
+    <repeat name="categories" title="Categories used to filter genes" min="0">
+      <param name="name" type="text" value="" label="Name of the categorical variable to filter on"/>
+      <param name="values" type="text" value="" label="Comma-separated values"/>
+    </repeat>
+
+    <repeat name="subsets" title="Subsets used to filter genes" min="0">
+      <param name="name" type="text" value="" label="Name of the categorical variable to filter on"/>
+      <param name="subset" type="data" format="tabular" label="List of values"/>
+    </repeat>
     <expand macro="export_mtx_params"/>
   </inputs>
 
@@ -57,7 +65,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-genes.py
         <param name="max" value="1e9"/>
       </repeat>
       <repeat name="parameters">
-        <param name="name" value="n_counts"/>
+        <param name="name" value="gene:n_counts"/>
         <param name="min" value="0"/>
         <param name="max" value="1e9"/>
       </repeat>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
@@ -2,55 +2,68 @@
 <tool id="scanpy_find_cluster" name="Scanpy FindCluster" version="@TOOL_VERSION@+galaxy1">
   <description>based on community detection on KNN graph</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-find-cluster.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    #if $output_cluster
-        --output-text-file output.tsv
-    #end if
-    #if $settings.default == "false"
-        --flavor '${settings.flavor}'
+PYTHONIOENCODING=utf-8 scanpy-find-cluster
+    ${method}
+#if $settings.default == "false"
+    --use-graph '${settings.use_graph}'
+    #if $settings.key_added
         --key-added '${settings.key_added}'
-        -s '${settings.random_seed}'
-        #if $settings.flavor == "vtraag" and $settings.resolution_file
-            --resolution \$( cat $settings.resolution_file )
-        #elif $settings.flavor == "vtraag"
-            --resolution '${settings.resolution}'
-        #end if
-        #if $settings.restrict_to
-            --restrict-to '${settings.restrict_to}'
-        #end if
-        #if $settings.use_weights
-            --use-weights
-        #end if
     #end if
+    #if $settings.resolution_file
+        --resolution \$( cat $settings.resolution_file )
+    #elif $settings.resolution
+        --resolution '${settings.resolution}'
+    #end if
+    #if $settings.restrict_to
+        --restrict-to '${settings.restrict_to}'
+    #end if
+    #if $settings.use_weights
+        --use-weights
+    #end if
+    --random-state '${settings.random_seed}'
+    ${settings.directed}
+#end if
+#if $output_cluster
+    --export-cluster output.tsv
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
     <param name="output_cluster" type="boolean" checked="true" label="Output cluster in two column text format"/>
+
+    <param name="method" type="select" label="Clustering algorithm">
+      <option value="louvain" selected="true">Louvain</option>
+      <option value="leiden">Leiden</option>
+    </param>
+
     <conditional name="settings">
       <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
       <when value="true"/>
       <when value="false">
-        <param name="flavor" argument="--flavor" type="select" label="Use the indicated representation">
-          <option value="vtraag" selected="true">vtraag</option>
-          <option value="igraph">igraph</option>
-        </param>
-        <param name="resolution" argument="--resolution" type="float" value="1.0" label="Resolution, high value for more and smaller clusters"/>
-        <param name="resolution_file" argument="--resolution" type="data" format="txt,tsv" optional="true" label="File with resolution, use with parameter iterator. Overrides the resolution setting"/>
-        <param name="restrict_to" argument="--restrict-to" type="text" optional="true" label="Restrict clustering to certain sample categories"/>
-        <param name="key_added" argument="--key-added" type="text" value="louvain" label="Key under which to add the cluster labels (do not change unless you know what you are doing)"/>
+        <param name="use_graph" argument="--use-graph" value="neighbors" type="text"
+            label="Name of the slot that holds the KNN graph"/>
+        <param name="key_added" argument="--key-added" type="text" optional="true"
+            label="Additional suffix to the name of the slot to save the calculated trajectory"/>
+
+        <param name="resolution" argument="--resolution" type="float" min="0.0" value="1.0"
+               label="Resolution, high value for more and smaller clusters"/>
+        <param name="resolution_file" argument="--resolution" type="data" format="txt,tsv" optional="true"
+               label="File with resolution, use with parameter iterator. Overrides the resolution setting"/>
+        <param name="restrict_to" argument="--restrict-to" type="text" optional="true"
+               label="Restrict clustering to certain sample categories"/>
         <param name="use_weights" argument="--use-weights" type="boolean" checked="false" label="Use weights from knn graph"/>
         <param name="random_seed" argument="--random-seed" type="integer" value="0" label="Seed for random number generator"/>
+        <param name="directed" argument="--directed" type="boolean" truevalue="--directed" falsevalue="--undirected" checked="true"
+               label="Interpret the adjacency matrix as directed graph."/>
       </when>
     </conditional>
   </inputs>
@@ -69,7 +82,6 @@ PYTHONIOENCODING=utf-8 scanpy-find-cluster.py
       <param name="output_format" value="anndata"/>
       <param name="output_txt" value="true"/>
       <param name="default" value="false"/>
-      <param name="flavor" value="vtraag"/>
       <param name="resolution" value="1.0"/>
       <param name="random_seed" value="0"/>
       <output name="output_h5" file="find_cluster.h5" ftype="h5" compare="sim_size"/>
@@ -78,17 +90,18 @@ PYTHONIOENCODING=utf-8 scanpy-find-cluster.py
   </tests>
 
   <help><![CDATA[
-===========================================
-Cluster cells into subgroups (`tl.louvain`)
-===========================================
+======================================================================
+Cluster cells into subgroups (`scanpy.tl.louvain`, `scanpy.tl.leiden`)
+======================================================================
 
-Cluster cells using the Louvain algorithm (Blondel et al, 2008) in the implementation
-of Traag et al,2017. The Louvain algorithm has been proposed for single-cell
-analysis by Levine et al, 2015.
+Cluster cells using the Louvain algorithm (Blondel et al, 2008) in the
+implementation of Traag et al, 2017, or the Leiden algorithm (Traag et al,
+2019). The Louvain algorithm has been proposed for single-cell analysis by
+Levine et al, 2015.
 
 This requires to run `Scanpy ComputeGraph`, first.
 
-It yields `louvain`, generated cluster label.
+It by default yields `louvain` or `leiden`, generated cluster label.
 
 @HELP@
 
@@ -97,6 +110,7 @@ It yields `louvain`, generated cluster label.
   <expand macro="citations">
     <citation type="doi">10.1088/1742-5468/2008/10/P10008</citation>
     <citation type="doi">10.1016/j.cell.2015.05.047</citation>
+    <citation type="doi">10.1038/s41598-019-41695-z</citation>
     <citation type="doi">10.5281/zenodo.35117</citation>
   </expand>
 </tool>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
@@ -2,56 +2,59 @@
 <tool id="scanpy_find_markers" name="Scanpy FindMarkers" version="@TOOL_VERSION@+galaxy1">
   <description>to find differentially expressed genes between groups</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-find-markers.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    -n '${n_genes}'
-    #if $output_markers
-        --output-text-file output.csv
-    #end if
-    #if $settings.default == "false"
-        -g '${settings.groupby}'
-        --reference '${settings.reference}'
-        --method '${settings.method}'
-        #if $settings.use_raw == "false"
-            --no-raw
-        #end if
-        #if $settings.rankby_abs
-            --rankby_abs
-        #end if
-        #if $settings.groups
-            --groups '${settings.groups}'
-        #end if
+PYTHONIOENCODING=utf-8 scanpy-find-markers
+#if $output_markers
+    --save output.csv
 #end if
+    --n-genes '${n_genes}'
+    --groupby '${groupby}'
+#if $settings.default == "false"
+    --method '${settings.method}'
+    ${settings.use_raw}
+    ${settings.rankby_abs}
+    #if $settings.groups
+        --groups '${settings.groups}'
+    #end if
+    --reference '${settings.reference}'
+    --filter-params 'min_in_group_fraction:${settings.min_in_group_fraction},max_out_group_fraction:${settings.max_out_group_fraction},min_fold_change:${settings.min_fold_change}'
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
-    <param name="n_genes" argument="--n-genes" type="integer" value="50" label="Number of top genes to show per group/cluster"/>
     <param name="output_markers" type="boolean" checked="true" label="Output markers table in csv format"/>
+    <param name="n_genes" argument="--n-genes" type="integer" value="50" label="Number of top genes to show per group/cluster"/>
+    <param name="groupby" argument="--groupby" type="text" value="louvain" label="The sample grouping/clustering to use."/>
     <conditional name="settings">
       <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
       <when value="true"/>
       <when value="false">
-        <param name="groupby" argument="--groupby" type="text" value="louvain" label="The sample grouping/clustering to use."/>
-        <param name="use_raw" type="boolean" checked="true" label="Use raw attribute if present"/>
-        <param name="reference" argument="--reference" type="text" value="rest" label="If 'rest', compare to the union of the rest of the group/cluster. If a group identifier, compare to that group"/>
         <param name="method" argument="--method" type="select" label="Method for testing differentially expressed genes">
           <option value="t-test_overestim_var" selected="true">t-test with over-estimated variance</option>
           <option value="t-test">t-test</option>
           <option value="wilcoxon">wilcoxon test, currently broken don't use</option>
           <option value="logreg">logistic regression</option>
         </param>
-        <param name="rankby_abs" argument="--rankby_abs" type="boolean" checked="false" label="Rank by absolute value of the scores instead of the scores"/>
+        <param name="use_raw" type="boolean" truevalue="--use-raw" falsevalue="--no-raw" checked="true"
+               label="Use raw attribute if present"/>
+        <param name="rankby_abs" argument="--rankby_abs" type="boolean" truevalue="--rankby-abs" falsevalue="" checked="false"
+               label="Rank by absolute value of the scores instead of the scores"/>
         <param name="groups" argument="--groups" optional="true" type="text" label="Subset of groups/clusters to which comparisons shell be restricted."/>
+        <param name="reference" argument="--reference" type="text" value="rest" label="If 'rest', compare to the union of the rest of the group/cluster. If a group identifier, compare to that group"/>
+        <param name="min_in_group_fraction" type="float" min="0.0" max="1.0" value="0.25" label="Minimum in-group fraction"
+               help="Post-test filtering to only keep genes expressed in at least this fraction of cells in the test group."/>
+        <param name="max_out_group_fraction" type="float" min="0.0" max="1.0" value="0.5" label="Maximum out-group fraction"
+               help="Post-test filtering to only keep genes expressed in at most this fraction of cells in the reference group."/>
+        <param name="min_fold_change" type="float" value="2" label="Minimum fold change"
+               help="Post-test filtering to only keep genes with at least this fold change of expression relative to the reference group."/>
       </when>
     </conditional>
   </inputs>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
@@ -31,12 +31,12 @@ PYTHONIOENCODING=utf-8 scanpy-find-variable-genes
       </param>
       <when value="seurat">
         <param name="min_mean" argument="--min-mean" type="float" min="0" value="0.0125"
-               label="Min value for mean expression (in log1p scale)"/>
+               label="Min value for normalised mean expression (in log1p scale)"/>
         <param name="max_mean" argument="--max-mean" type="float" min="0" value="3"
-               label="Max value for mean expresssion (in log1p scale)"/>
+               label="Max value for normalised mean expresssion (in log1p scale)"/>
         <param name="min_disp" argument="--min-disp" type="float" min="0" value="0.5"
                label="Min value for dispersion of expression"/>
-        <param name="max_disp" argument="--max-disp" type="float" min="0" value="20"
+        <param name="max_disp" argument="--max-disp" type="float" min="0" value="50"
                label="Max value for dispersion of expresssion"/>
       </when>
       <when value="cell_ranger">

--- a/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
@@ -2,47 +2,51 @@
 <tool id="scanpy_find_variable_genes" name="Scanpy FindVariableGenes" version="@TOOL_VERSION@+galaxy0">
   <description>based on normalised dispersion of expression</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-find-variable-genes.py -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    --flavor '${flavor}'
-    -b '${n_bin}'
-    #if $parameters
-        #set pars = ','.join([str($p['name']) for $p in $parameters])
-        -p '${pars}'
-        #set mins = ','.join([str($p['min']) for $p in $parameters])
-        -l '${mins}'
-        #set maxs = ','.join([str($p['max']) for $p in $parameters])
-        -j '${maxs}'
-    #end if
-    #if $n_top_gene
-        -n '${n_top_gene}'
-    #end if
+PYTHONIOENCODING=utf-8 scanpy-find-variable-genes
+    --flavor '${method.flavor}'
+#if $method.flavor == 'seurat'
+    --mean-limits ${method.min_mean} ${method.max_mean}
+    --disp-limits ${method.min_disp} ${method.max_disp}
+#else
+    --n-top-genes ${method.n_top_gene}
+#end if
+    --n-bins '${n_bin}'
+    ${filter}
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
-    <param name="flavor" argument="--flavor" type="select" value="seurat" label="Flavor of computing normalised dispersion">
-      <option value="seurat">Seurat</option>
-      <option value="cell_ranger">Cell-ranger</option>
-    </param>
-    <repeat name="parameters" min="1" title="Parameters used to find variable genes">
-      <param name="name" type="select" label="Name of parameter to filter on">
-        <option value="mean">Mean of expression</option>
-        <option value="disp">Dispersion of expression</option>
+    <conditional name="method">
+      <param name="flavor" argument="--flavor" type="select" label="Flavor of computing normalised dispersion">
+        <option value="seurat" selected="true">Seurat</option>
+        <option value="cell_ranger">Cell-ranger</option>
       </param>
-      <param name="min" type="float" value="0" label="Min value"/>
-      <param name="max" type="float" value="1e9" label="Max value"/>
-    </repeat>
+      <when value="seurat">
+        <param name="min_mean" argument="--min-mean" type="float" min="0" value="0.0125"
+               label="Min value for mean expression (in log1p scale)"/>
+        <param name="max_mean" argument="--max-mean" type="float" min="0" value="3"
+               label="Max value for mean expresssion (in log1p scale)"/>
+        <param name="min_disp" argument="--min-disp" type="float" min="0" value="0.5"
+               label="Min value for dispersion of expression"/>
+        <param name="max_disp" argument="--max-disp" type="float" min="0" value="20"
+               label="Max value for dispersion of expresssion"/>
+      </when>
+      <when value="cell_ranger">
+        <param name="n_top_gene" argument="--n-top-genes" type="integer" value="2000"
+               label="Number of top variable genes to keep"/>
+      </when>
+    </conditional>
     <param name="n_bin" argument="--n-bins" type="integer" value="20" label="Number of bins for binning the mean expression"/>
-    <param name="n_top_gene" argument="--n-top-genes" type="integer" optional="true" label="Number of top variable genes to keep"/>
+    <param name="filter" argument="--subset" type="boolean" truevalue="--subset" falsevalue="" checked="false"
+           label="Remove genes not marked as highly variable"/>
   </inputs>
 
   <outputs>
@@ -56,26 +60,20 @@ PYTHONIOENCODING=utf-8 scanpy-find-variable-genes.py -i input.h5
       <param name="output_format" value="anndata"/>
       <param name="flavor" value="seurat"/>
       <param name="n_bin" value="20"/>
-      <repeat name="parameters">
-        <param name="name" value="mean"/>
-        <param name="min" value="0.0125"/>
-        <param name="max" value="3"/>
-      </repeat>
-      <repeat name="parameters">
-        <param name="name" value="disp"/>
-        <param name="min" value="0.5"/>
-        <param name="max" value="1e9"/>
-      </repeat>
+      <param name="min_mean" value="0.0125"/>
+      <param name="max_mean" value="3"/>
+      <param name="min_disp" value="0.5"/>
+      <param name="max_disp" value="1e9"/>
       <output name="output_h5" file="find_variable_genes.h5" ftype="h5" compare="sim_size"/>
     </test>
   </tests>
 
   <help><![CDATA[
-============================================================
-Extract highly variable genes (`pp.filter_genes_dispersion`)
-============================================================
+==============================================================
+Mark highly variable genes (`scanpy.pp.highly_variable_genes`)
+==============================================================
 
-Depending on `flavor`, this reproduces the R-implementations of Seurat and Cell Ranger.
+Depending on `flavor`, this reproduces the R-implementations of Seurat or Cell Ranger.
 
 The normalized dispersion is obtained by scaling with the mean and standard
 deviation of the dispersions for genes falling into a given bin for mean

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -1,34 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy0">
   <description>to derive kNN graph</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-neighbours.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    #if $settings.default == "false"
-        -N '${settings.n_neighbours}'
-        -m '${settings.method}'
-        -s '${settings.random_seed}'
-        #if $settings.use_rep != "auto"
-            -r '${settings.use_rep}'
-        #end if
-        #if $settings.n_pcs
-            -n '${settings.n_pcs}'
-        #end if
-        #if $settings.knn
-            --knn
-        #end if
-        #if $settings.metric
-            -M '${settings.metric}'
-        #end if
+PYTHONIOENCODING=utf-8 scanpy-neighbours
+#if $settings.default == "false"
+    --n-neighbors '${settings.n_neighbours}'
+    --method '${settings.method}'
+    -s '${settings.random_seed}'
+    #if $settings.use_rep != "auto"
+        -r '${settings.use_rep}'
     #end if
+    #if $settings.n_pcs
+        --n-pcs '${settings.n_pcs}'
+    #end if
+    #if $settings.knn
+        --knn
+    #end if
+    #if $settings.metric
+        -M '${settings.metric}'
+    #end if
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 ]]></command>
 
   <inputs>
@@ -40,9 +38,8 @@ PYTHONIOENCODING=utf-8 scanpy-neighbours.py
       <when value="false">
         <param name="n_neighbours" argument="--n-neighbors" type="integer" value="15" label="Maximum number of neighbours used"/>
         <param name="use_rep" type="select" label="Use the indicated representation">
-          <option value="X_pca">X_pca, use PCs</option>
+          <option value="X_pca" selected="true">X_pca, use PCs</option>
           <option value="X">X, use normalised expression values</option>
-          <option value="auto" selected="true">Automatically chosen based on problem size</option>
         </param>
         <param name="n_pcs" argument="--n-pcs" type="integer" value="50" optional="true" label="Number of PCs to use"/>
         <param name="knn" argument="--knn/--no-knn" type="boolean" checked="true" label="Use hard threshold to restrict neighbourhood size (otherwise use a Gaussian kernel to down weight distant neighbours)"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -7,23 +7,18 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-neighbours
+PYTHONIOENCODING=utf-8 scanpy-neighbors
 #if $settings.default == "false"
     --n-neighbors '${settings.n_neighbours}'
     --method '${settings.method}'
-    -s '${settings.random_seed}'
+    --random-state '${settings.random_seed}'
     #if $settings.use_rep != "auto"
-        -r '${settings.use_rep}'
+        --use-rep '${settings.use_rep}'
     #end if
     #if $settings.n_pcs
         --n-pcs '${settings.n_pcs}'
     #end if
-    #if $settings.knn
-        --knn
-    #end if
-    #if $settings.metric
-        -M '${settings.metric}'
-    #end if
+    ${settings.knn}
 #end if
     @INPUT_OPTS@
     @OUTPUT_OPTS@
@@ -42,12 +37,12 @@ PYTHONIOENCODING=utf-8 scanpy-neighbours
           <option value="X">X, use normalised expression values</option>
         </param>
         <param name="n_pcs" argument="--n-pcs" type="integer" value="50" optional="true" label="Number of PCs to use"/>
-        <param name="knn" argument="--knn/--no-knn" type="boolean" checked="true" label="Use hard threshold to restrict neighbourhood size (otherwise use a Gaussian kernel to down weight distant neighbours)"/>
+        <param name="knn" argument="--knn" type="boolean" truevalue="" falsevalue="--no-knn" checked="true"
+               label="Use hard threshold to restrict neighbourhood size (otherwise use a Gaussian kernel to down weight distant neighbours)"/>
         <param name="method" argument="--method" type="select" label="Method for calculating connectivity">
           <option value="umap" selected="true">UMAP</option>
           <option value="gauss">Gaussian</option>
         </param>
-        <param name="metric" argument="--metric" type="text" value="euclidean" label="Distance metric"/>
         <param name="random_seed" argument="--random-seed" type="integer" value="0" label="Seed for random number generator"/>
       </when>
     </conditional>
@@ -68,7 +63,6 @@ PYTHONIOENCODING=utf-8 scanpy-neighbours
       <param name="knn" value="true"/>
       <param name="random_seed" value="0"/>
       <param name="method" value="umap"/>
-      <param name="metric" value="euclidean"/>
       <output name="output_h5" file="compute_graph.h5" ftype="h5" compare="sim_size"/>
     </test>
   </tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
@@ -2,33 +2,34 @@
 <tool id="scanpy_normalise_data" name="Scanpy NormaliseData" version="@TOOL_VERSION@+galaxy1">
   <description>to make all cells having the same total expression</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-normalise-data.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    -s '${scale_factor}'
-    #if $save_raw
-        '${save_raw}'
-    #end if
-    @EXPORT_MTX_OPTS@
+PYTHONIOENCODING=utf-8 scanpy-normalise-data
+    --normalize-to ${scale_factor}
+    --fraction ${fraction}
+    --save-raw ${save_raw}
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
-    <param name="scale_factor" argument="--scale-factor" type="float" value="1e4" label="Target number to normalise to" help="Aimed counts per cell after normalisation, default: 1e4"/>
-    <param name="save_raw" argument="--save-raw" type="boolean" truevalue="--save-raw" falsevalue="" checked="true" label="Save pre-normalised data" help="Save raw quantification in log scale before normalisation."/>
+    <param name="scale_factor" argument="--normalize-to" type="float" value="1e4" min="0"
+           label="Target number to normalise to" help="Aimed counts per cell after normalisation."/>
+    <param name="fraction" argument="--fraction" type="float" value="1" min="0" max="1"
+           label="Exclude top expressed genes until the remaining account for no greater than specified fraction of total counts"
+           help="Only non-excluded genes will sum up the target number."/>
+    <param name="save_raw" argument="--save-raw" type="boolean" truevalue="yes" falsevalue="no" checked="true"
+           label="Save normalised data in `.raw`" help="The saved normalised data are log1p transformed."/>
     <expand macro="export_mtx_params"/>
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Normalized data" />
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Normalised data"/>
     <expand macro="export_mtx_outputs"/>
   </outputs>
 
@@ -44,12 +45,13 @@ PYTHONIOENCODING=utf-8 scanpy-normalise-data.py
   </tests>
 
   <help><![CDATA[
-=========================================================
-Normalize total counts per cell (`pp.normalize_per_cell`)
-=========================================================
+=============================================================
+Normalise total counts per cell (`scanpy.pp.normalize_total`)
+=============================================================
 
-Normalize each cell by total counts over all genes, so that every cell has
-the same total count after normalization.
+Normalise each cell by total counts over all genes (excluding top expressed
+genes if so required), so that every cell has the same total count after
+normalisation.
 
 Similar functions are used, for example, by Seurat, Cell Ranger or SPRING.
 

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -14,6 +14,9 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot embed
     ${use_raw}
     --legend-loc '${legend_loc}'
     --legend-fontsize '${legend_fontsize}'
+#if $point_size
+    --size ${point_size}
+#end if
     @PLOT_OPTS@
 ]]></command>
 
@@ -27,6 +30,8 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot embed
       <option value="on data">On data</option>
     </param>
     <param name="legend_fontsize" argument="--legend-fontsize" type="integer" value="15" label="Legend font size"/>
+    <param name="point_size" argument="--size" type="integer" optional="true" label="Point size"
+           help="Automatically determined if not specified."/>
     <expand macro="output_plot_params"/>
   </inputs>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tool id="scanpy_plot_embed" name="Scanpy PlotEmbed" version="@TOOL_VERSION@+galaxy0">
+  <description>visualise cell embeddings</description>
+  <macros>
+    <import>scanpy_macros2.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="exit_code"><![CDATA[
+ln -s '${input_obj_file}' input.h5 &&
+PYTHONIOENCODING=utf-8 scanpy-cli plot embed
+    @INPUT_OPTS@
+    @PLOT_OPTS@
+]]></command>
+
+  <inputs>
+    <expand macro="input_object_params"/>
+    <expand macro="output_plot_params"/>
+  </inputs>
+
+  <outputs>
+    <data name="output_png" format="png" from_work_dir="output.png" label="${tool.name} on ${on_string}: embedding plot"/>
+  </outputs>
+
+  <tests>
+    <test>
+      <param name="input_obj_file" value="find_cluster.h5"/>
+      <param name="input_format" value="anndata"/>
+      <param name="color_by" value="louvain"/>
+      <output name="output_png" file="run_tsne.png" ftype="png" compare="sim_size"/>
+    </test>
+  </tests>
+
+  <help><![CDATA[
+==================================================================
+t-distributed stochastic neighborhood embedding (tSNE) (`tl.tsne`)
+==================================================================
+
+t-distributed stochastic neighborhood embedding (tSNE) (Maaten et al, 2008) has been
+proposed for visualizating single-cell data by (Amir et al, 2013). Here, by default,
+we use the implementation of *scikit-learn* (Pedregosa et al, 2011).
+
+It yields `X_tsne`, tSNE coordinates of data.
+
+@HELP@
+
+@VERSION_HISTORY@
+]]></help>
+  <expand macro="citations"/>
+</tool>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -56,6 +56,10 @@ Plot embeddings of a given method of dimensionality reduction
 It yields a scatter plot in png format, wherein cells are placed in space of
 reduced dimensionality and coloured by attribute of choice.
 
+Requires calculating the specified embeddings first. For example, to make
+UMAP/TSNE plots, run `Scanpy RunUMAP`/`Scanpy RunTSNE` first, then enter
+"umap"/"tsne" as the name of the embedding to plot here.
+
 @HELP@
 
 @VERSION_HISTORY@

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -9,11 +9,24 @@
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-cli plot embed
     @INPUT_OPTS@
+    --basis '${basis}'
+    --color '${color_by}'
+    ${use_raw}
+    --legend-loc '${legend_loc}'
+    --legend-fontsize '${legend_fontsize}'
     @PLOT_OPTS@
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
+    <param name="basis" argument="--basis" type="text" label="Name of the embedding to plot"/>
+    <param name="color_by" argument="--color" type="text" label="Color by attributes, comma separated texts"/>
+    <param name="use_raw" argument="--use-raw" type="boolean" checked="true" truevalue="--use-raw" falsevalue="--no-raw" label="Use raw attributes if present"/>
+    <param name="legend_loc" argument="--legend-loc" type="select" label="Location of legend">
+      <option value="right margin" selected="true">Right margin</option>
+      <option value="on data">On data</option>
+    </param>
+    <param name="legend_fontsize" argument="--legend-fontsize" type="integer" value="15" label="Legend font size"/>
     <expand macro="output_plot_params"/>
   </inputs>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -31,15 +31,12 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot embed
   </tests>
 
   <help><![CDATA[
-==================================================================
-t-distributed stochastic neighborhood embedding (tSNE) (`tl.tsne`)
-==================================================================
+=============================================================
+Plot embeddings of a given method of dimensionality reduction
+=============================================================
 
-t-distributed stochastic neighborhood embedding (tSNE) (Maaten et al, 2008) has been
-proposed for visualizating single-cell data by (Amir et al, 2013). Here, by default,
-we use the implementation of *scikit-learn* (Pedregosa et al, 2011).
-
-It yields `X_tsne`, tSNE coordinates of data.
+It yields a scatter plot in png format, wherein cells are placed in space of
+reduced dimensionality and coloured by attribute of choice.
 
 @HELP@
 

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tool id="scanpy_plot_trajectory" name="Scanpy PlotTrajectory" version="@TOOL_VERSION@+galaxy0">
+  <description>visualise cell trajectories</description>
+  <macros>
+    <import>scanpy_macros2.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="exit_code"><![CDATA[
+ln -s '${input_obj_file}' input.h5 &&
+PYTHONIOENCODING=utf-8 scanpy-cli plot paga
+    --type ${type}
+#if $use_key
+    --use-key '${use_key}'
+#end if
+    --layout ${layout}
+#if $settings.default == "false"
+    --threshold ${settings.threshold}
+    #if $settings.root
+        --root ${settings.root}
+    #end if
+        ${settings.single_component}
+    #if $settings.solid_edges
+        --solid-edges ${settings.solid_edges}
+    #end if
+    #if $settings.color
+        --color '${settings.color}'
+    #end if
+    #if $settings.node_size
+        --node-size-scale ${settings.node_size}
+    #end if
+    #if $settings.node_font
+        --fontsize ${settings.node_font}
+    #end if
+#end if
+    @INPUT_OPTS@
+    @PLOT_OPTS@
+]]></command>
+
+  <inputs>
+    <expand macro="input_object_params"/>
+    <param name="type" argument="--type" type="select" label="Figure type">
+      <option value="paga">Trajectory</option>
+      <option value="paga_compare" selected="true">Trajectory + Embedding</option>
+    </param>
+    <param name="use_key" argument="--use-key" type="text" value="paga"
+           label="The key in `.uns` that contains trajectory information"/>
+    <param name="layout" argument="--layout" type="select" label="Layout functions">
+      <option value="fa" selected="true">ForceAtlas2</option>
+      <option value="fr">Fruchterman-Reingold</option>
+      <option value="rt">Reingold-Tilford</option>
+    </param>
+    <expand macro="output_plot_params"/>
+    <conditional name="settings">
+      <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
+      <when value="true"/>
+      <when value="false">
+        <param name="threshold" argument="--threshold" type="float" min="0" value="0.01"
+               label="Do not draw edges with weights below this threshold"
+               help="Set to 0 to include all edges."/>
+        <param name="root" argument="--root" type="integer" min="0" value="0"
+               label="The index of the root node when choosing a tree layout"/>
+        <param name="single_component" argument="--single-component" type="boolean" truevalue="--single-component" falsevalue="" checked="false"
+               label="Restrict to the largest connected component"/>
+        <param name="solid_edges" argument="--solid-edges" type="select" label="Edges to be drawn in solid black">
+          <option value="connectivities" selected="true">connectivities</option>
+          <option value="connectivities_tree">connectivities_tree</option>
+        </param>
+        <param name="color" argument="--color" type="text" label="Name of cell annotation or gene that is used to color the nodes"/>
+        <param name="node_size" argument="--node-size-scale" type="float" value="1.0"
+               label="Increase or decrease the size of the nodes"/>
+        <param name="node_font" argument="--fontsize" type="integer" min="1" optional="true"
+               label="Font size for the node labels"/>
+      </when>
+    </conditional>
+  </inputs>
+
+  <outputs>
+    <data name="output_png" format="png" from_work_dir="output.png" label="${tool.name} on ${on_string}: trajectory plot"/>
+  </outputs>
+
+  <tests>
+    <test>
+      <param name="input_obj_file" value="find_cluster.h5"/>
+      <param name="input_format" value="anndata"/>
+      <param name="type" value="paga_compare"/>
+      <output name="output_png" file="paga_compare.png" ftype="png" compare="sim_size"/>
+    </test>
+  </tests>
+
+  <help><![CDATA[
+===============================================================
+Plot PAGA-inferred trajectories (`scanpy.pl.paga/paga_compare`)
+===============================================================
+
+Depending on the selected options, it yields a plot of a graph representing
+inferred trajectory, or a trajectory graph side-by-side with a scatter plot of
+cells embedded to space of reduced dimensionality in png format.
+
+It requires running PAGA, first.
+
+@HELP@
+
+@VERSION_HISTORY@
+]]></help>
+  <expand macro="citations"/>
+</tool>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -8,11 +8,13 @@
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-cli plot paga
-    --type ${type}
 #if $use_key
     --use-key '${use_key}'
 #end if
     --layout ${layout}
+#if $basis
+    --basis ${basis}
+#end if
 #if $settings.default == "false"
     --threshold ${settings.threshold}
     #if $settings.root
@@ -31,6 +33,9 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
     #if $settings.node_font
         --fontsize ${settings.node_font}
     #end if
+    #if $settings.edge_width
+        --edge-width-scale ${settings.edge_width}
+    #end if
 #end if
     @INPUT_OPTS@
     @PLOT_OPTS@
@@ -38,10 +43,6 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
 
   <inputs>
     <expand macro="input_object_params"/>
-    <param name="type" argument="--type" type="select" label="Figure type">
-      <option value="paga">Trajectory</option>
-      <option value="paga_compare" selected="true">Trajectory + Embedding</option>
-    </param>
     <param name="use_key" argument="--use-key" type="text" value="paga"
            label="The key in `.uns` that contains trajectory information"/>
     <param name="layout" argument="--layout" type="select" label="Layout functions">
@@ -49,6 +50,8 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
       <option value="fr">Fruchterman-Reingold</option>
       <option value="rt">Reingold-Tilford</option>
     </param>
+    <param name="basis" argument="--basis" type="text" optional="true" label="Name of the embedding to plot"
+           help="Must be a key of `.obsm` without the prefix 'X_', e.g. 'umap'."/>
     <expand macro="output_plot_params"/>
     <conditional name="settings">
       <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
@@ -70,6 +73,8 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
                label="Increase or decrease the size of the nodes"/>
         <param name="node_font" argument="--fontsize" type="integer" min="1" optional="true"
                label="Font size for the node labels"/>
+        <param name="edge_width" argument="--edge-width-scale" type="float" value="1.0"
+               label="Increase or decrease the width of the edges"/>
       </when>
     </conditional>
   </inputs>

--- a/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
@@ -52,9 +52,9 @@ PYTHONIOENCODING=utf-8 scanpy-read-10x
   </tests>
 
   <help><![CDATA[
-==========================================================
-Read 10x-Genomics-formatted mtx directory (`read_10x_mtx`)
-==========================================================
+=================================================================
+Read 10x-Genomics-formatted mtx directory (`scanpy.read_10x_mtx`)
+=================================================================
 
 The mtx directory should contain:
 

--- a/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
@@ -2,24 +2,33 @@
 <tool id="scanpy_read_10x" name="Scanpy Read10x" version="@TOOL_VERSION@+galaxy0">
   <description>into hdf5 object handled by scanpy</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${matrix}' matrix.mtx &&
 ln -s '${genes}' genes.tsv &&
 ln -s '${barcodes}' barcodes.tsv &&
-PYTHONIOENCODING=utf-8 scanpy-read-10x.py
-    -d ./
-    -o read_10x.h5
-    -F '${output_format}'
-    -v '${var_names}'
+PYTHONIOENCODING=utf-8 scanpy-read-10x
+    --input-10x-mtx ./
+    --var-names '${var_names}'
+#if $cell_meta:
+    --extra-obs '${cell_meta}'
+#end if
+#if $gene_meta:
+    --extra-var '${gene_meta}'
+#end if
+    @OUTPUT_OPTS@
 ]]></command>
 
   <inputs>
     <param name="matrix" type="data" format="txt" label="Expression matrix in sparse matrix format (.mtx)"/>
     <param name="genes" type="data" format="tsv,tabular" label="Gene table"/>
     <param name="barcodes" type="data" format="tsv,tabular" label="Barcode/cell table"/>
+    <param name="cell_meta" type="data" format="tsv,tabular" label="Cell metadata table" optional="true"
+           help="Requires a header row and index column that matches the barcode/cell table"/>
+    <param name="gene_meta" type="data" format="tsv,tabular" label="Gene metadata table" optional="true"
+           help="Requires a header row and index column that matches the gene table"/>
     <expand macro="output_object_params"/>
     <param name="var_names" type="select" label="Attribute used as annotation index">
       <option value="gene_ids" selected="true">Gene ID</option>
@@ -28,7 +37,7 @@ PYTHONIOENCODING=utf-8 scanpy-read-10x.py
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="read_10x.h5" label="${tool.name} on ${on_string}: ${output_format}"/>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: ${output_format}"/>
   </outputs>
 
   <tests>
@@ -36,8 +45,9 @@ PYTHONIOENCODING=utf-8 scanpy-read-10x.py
       <param name="matrix" value="matrix.mtx"/>
       <param name="genes" value="genes.tsv"/>
       <param name="barcodes" value="barcodes.tsv"/>
+      <!-- <param name="cell_meta" value=""/> -->
       <param name="output_format" value="anndata"/>
-      <output name="output_h5" file="read_10x.h5" ftype="h5" compare="sim_size"/>
+      <output name="output_h5" file="output.h5" ftype="h5" compare="sim_size"/>
     </test>
   </tests>
 
@@ -54,8 +64,9 @@ The mtx directory should contain:
 
 3) A barcode/cell table of at least one column giving the barcode/cell IDs.
 
-The above-mentioned files can be obtained by running `EBI SCXA Data Retrieval`
-with a dataset accession.
+The above-mentioned files can be obtained by running `EBI SCXA Data Retrieval` with a dataset accession or `Human Cell Atlas Matrix Downloader` with a project name/label/UUID.
+
+Additionally, cell and/or gene metadata table can be provided as tab-separated text with a header row and an index column that matches the respective barcode/cell and/or gene table.
 
 
 @HELP@

--- a/tools/tertiary-analysis/scanpy/scanpy-regress-variable.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-regress-variable.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tool id="scanpy_regress_variable" name="Scanpy RegressOut" version="@TOOL_VERSION@+galaxy0">
+  <description>variables that might introduce batch effect</description>
+  <macros>
+    <import>scanpy_macros2.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="exit_code"><![CDATA[
+ln -s '${input_obj_file}' input.h5 &&
+PYTHONIOENCODING=utf-8 scanpy-regress
+    --keys '${keys}'
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
+]]></command>
+
+  <inputs>
+    <expand macro="input_object_params"/>
+    <expand macro="output_object_params"/>
+    <param name="keys" type="text" label="Variables to regress out" help="Use comma to separate multiple variables"/>
+  </inputs>
+
+  <outputs>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Scaled data"/>
+  </outputs>
+
+  <tests>
+    <test>
+      <param name="input_obj_file" value="find_variable_genes.h5"/>
+      <param name="input_format" value="anndata"/>
+      <param name="output_format" value="anndata"/>
+      <param name="keys" value="n_counts"/>
+      <output name="output_h5" file="scale_data.h5" ftype="h5" compare="sim_size"/>
+    </test>
+  </tests>
+
+  <help><![CDATA[
+    .. class:: infomark
+
+    **What it does**
+
+    Regress out unwanted source of variance (`scanpy.pp.regress_out`)
+
+    @HELP@
+
+    @VERSION_HISTORY@
+]]></help>
+  <expand macro="citations"/>
+</tool>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tool id="scanpy_run_diffmap" name="Scanpy DiffusionMap" version="@TOOL_VERSION@+galaxy0">
+  <description>calculate diffusion components</description>
+  <macros>
+    <import>scanpy_macros2.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="exit_code"><![CDATA[
+ln -s '${input_obj_file}' input.h5 &&
+PYTHONIOENCODING=utf-8 scanpy-cli embed diffmap
+    --n-comps ${n_comps}
+#if $use_graph
+    --use-graph '${use_graph}'
+#end if
+#if $key_added
+    --key-added '${key_added}'
+#end if
+    $export_embed
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
+]]></command>
+
+  <inputs>
+    <expand macro="input_object_params"/>
+    <expand macro="output_object_params"/>
+
+    <param name="n_comps" argument="--n-comps" type="integer" min="2" value="10"
+           label="Number of diffusion components to calculate"/>
+    <param name="export_embed" argument="--export-embedding" type="boolean" checked="false"
+           truevalue="--export-embedding embed.tsv" falsevalue=""
+           label="Export embeddings as a tab-separated text table"/>
+    <param name="use_graph" argument="--use-graph" value="neighbors" type="text"
+           label="Name of the slot that holds the KNN graph"/>
+    <param name="key_added" argument="--key-added" type="text" optional="true"
+           label="Additional suffix to the name of the slot to save the calculated trajectory"/>
+  </inputs>
+
+  <outputs>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: diffmap object"/>
+    <data name="output_embed" format="tsv" from_work_dir="embed.tsv" label="${tool.name} on ${on_string}: diffmap embedding">
+      <filter>export_embed</filter>
+    </data>
+  </outputs>
+
+  <tests>
+    <test>
+      <param name="input_obj_file" value="diffmap.h5"/>
+      <param name="input_format" value="anndata"/>
+      <param name="output_format" value="anndata"/>
+      <param name="n_dcs" value="10"/>
+      <param name="root_attr" value="leiden"/>
+      <param name="root_value" value="1"/>
+      <param name="use_graph" value="neighbors"/>
+      <output name="output_h5" file="paga.h5" ftype="h5" compare="sim_size"/>
+    </test>
+  </tests>
+
+  <help><![CDATA[
+====================================================
+Calculate Diffusion Components (`scanpy.tl.diffmap`)
+====================================================
+
+Calculate diffusion components from single cell KNN graphs.
+
+This requires to run `Scanpy ComputeGraph`, first.
+
+It yields `X_diffmap`, the dimension-reduced representation in diffusion
+components space.
+
+@HELP@
+
+@VERSION_HISTORY@
+]]></help>
+  <expand macro="citations">
+    <citation type="doi">10.1186/s13059-019-1663-x</citation>
+  </expand>
+</tool>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
@@ -9,7 +9,7 @@
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-cli dpt
     --n-dcs $n_dcs
-    --root '${root_attr} ${root_value}'
+    --root '${root_attr}' '${root_value}'
 #if $n_branchings > 0
     --n-branchings ${n_branchings}
     --min-group-size ${min_group_size}

--- a/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
@@ -46,7 +46,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli dpt
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Cluster object"/>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: dpt object"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
@@ -8,7 +8,12 @@
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-cli dpt
-    --groups '${groups}'
+    --n-dcs $n_dcs
+    --root '${root_attr},${root_value}
+#if $n_branchings > 0
+    --n-branchings ${n_branchings}
+    --min-group-size ${min_group_size}
+#end if
 #if $use_graph
     --use-graph '${use_graph}'
 #end if
@@ -23,9 +28,9 @@ PYTHONIOENCODING=utf-8 scanpy-cli dpt
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
 
-    <param name="n_dcs" argument="--n-dcs" type="integer" value="10"
+    <param name="n_dcs" argument="--n-dcs" type="integer" min="2" value="10"
            label="Number of diffusion components to use"/>
-    <param name="n_branchings" argument="--n-branchings" type="integer" value="0"
+    <param name="n_branchings" argument="--n-branchings" min="0" type="integer" value="0"
            label="Number of branchings to detect"/>
     <param name="min_group_size" argument="--min-group-size" type="float" min="0" max="1" value="0"
            label="The fraction of total cells under which further splitting is skipped during recursive splitting of branches"

--- a/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tool id="scanpy_run_dpt" name="Scanpy DPT" version="@TOOL_VERSION@+galaxy0">
+  <description>diffusion pseudotime inference</description>
+  <macros>
+    <import>scanpy_macros2.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="exit_code"><![CDATA[
+ln -s '${input_obj_file}' input.h5 &&
+PYTHONIOENCODING=utf-8 scanpy-cli dpt
+    --groups '${groups}'
+#if $use_graph
+    --use-graph '${use_graph}'
+#end if
+#if $key_added
+    --key-added '${key_added}'
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
+]]></command>
+
+  <inputs>
+    <expand macro="input_object_params"/>
+    <expand macro="output_object_params"/>
+
+    <param name="n_dcs" argument="--n-dcs" type="integer" value="10"
+           label="Number of diffusion components to use"/>
+    <param name="n_branchings" argument="--n-branchings" type="integer" value="0"
+           label="Number of branchings to detect"/>
+    <param name="min_group_size" argument="--min-group-size" type="float" min="0" max="1" value="0"
+           label="The fraction of total cells under which further splitting is skipped during recursive splitting of branches"
+           help="Ignored when `Number of branchings to detect` is 0"/>
+    <param name="root_attr" argument="--root {attr},value" type="text"
+           label="Name of attribute that defines clustering"/>
+    <param name="root_value" argument="--root attr,{value}" type="text"
+           label="Name of the clustering that defines the root cell type"/>
+    <param name="use_graph" argument="--use-graph" value="neighbors" type="text"
+           label="Name of the slot that holds the KNN graph"/>
+    <param name="key_added" argument="--key-added" type="text" optional="true"
+           label="Additional suffix to the name of the slot to save the calculated trajectory"/>
+  </inputs>
+
+  <outputs>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Cluster object"/>
+  </outputs>
+
+  <tests>
+    <test>
+      <param name="input_obj_file" value="diffmap.h5"/>
+      <param name="input_format" value="anndata"/>
+      <param name="output_format" value="anndata"/>
+      <param name="n_dcs" value="10"/>
+      <param name="root_attr" value="leiden"/>
+      <param name="root_value" value="1"/>
+      <param name="use_graph" value="neighbors"/>
+      <output name="output_h5" file="paga.h5" ftype="h5" compare="sim_size"/>
+    </test>
+  </tests>
+
+  <help><![CDATA[
+================================================
+Calculate Diffusion Pseudotime (`scanpy.tl.dpt`)
+================================================
+
+Calculate diffusion pseudotime from single cell KNN graphs.
+
+This requires to run `Scanpy DiffusionMap` and `Scanpy FindCluster`, first.
+
+It yields `dpt_pseudotime`, diffusion pseudotime as an attribute for each cell.
+
+@HELP@
+
+@VERSION_HISTORY@
+]]></help>
+  <expand macro="citations">
+    <citation type="doi">10.1186/s13059-019-1663-x</citation>
+  </expand>
+</tool>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
@@ -9,7 +9,7 @@
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-cli dpt
     --n-dcs $n_dcs
-    --root '${root_attr},${root_value}
+    --root '${root_attr} ${root_value}'
 #if $n_branchings > 0
     --n-branchings ${n_branchings}
     --min-group-size ${min_group_size}
@@ -35,9 +35,9 @@ PYTHONIOENCODING=utf-8 scanpy-cli dpt
     <param name="min_group_size" argument="--min-group-size" type="float" min="0" max="1" value="0"
            label="The fraction of total cells under which further splitting is skipped during recursive splitting of branches"
            help="Ignored when `Number of branchings to detect` is 0"/>
-    <param name="root_attr" argument="--root {attr},value" type="text"
+    <param name="root_attr" argument="--root {attr} value" type="text"
            label="Name of attribute that defines clustering"/>
-    <param name="root_value" argument="--root attr,{value}" type="text"
+    <param name="root_value" argument="--root attr {value}" type="text"
            label="Name of the clustering that defines the root cell type"/>
     <param name="use_graph" argument="--use-graph" value="neighbors" type="text"
            label="Name of the slot that holds the KNN graph"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tool id="scanpy_run_paga" name="Scanpy PAGA" version="@TOOL_VERSION@+galaxy0">
+  <description>based on community detection on KNN graph</description>
+  <macros>
+    <import>scanpy_macros2.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="exit_code"><![CDATA[
+ln -s '${input_obj_file}' input.h5 &&
+PYTHONIOENCODING=utf-8 scanpy-cli paga
+    --groups '${groups}'
+#if $use_graph
+    --use-graph '${use_graph}'
+#end if
+#if $key_added
+    --key-added '${key_added}'
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
+]]></command>
+
+  <inputs>
+    <expand macro="input_object_params"/>
+    <expand macro="output_object_params"/>
+
+    <param name="groups" argument="--groups" type="text" label="Name of the clustering"/>
+    <param name="use_graph" argument="--use-graph" value="neighbors" type="text" label="Name of the slot that holds the KNN graph"/>
+    <param name="key_added" argument="--key-added" type="text" optional="true" label="Additional suffix to the name of the slot to save the calculated trajectory"/>
+  </inputs>
+
+  <outputs>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Cluster object"/>
+  </outputs>
+
+  <tests>
+    <test>
+      <param name="input_obj_file" value="compute_graph.h5"/>
+      <param name="input_format" value="anndata"/>
+      <param name="output_format" value="anndata"/>
+      <param name="groups" value="leiden"/>
+      <param name="use_graph" value="neighbors"/>
+      <output name="output_h5" file="paga.h5" ftype="h5" compare="sim_size"/>
+    </test>
+  </tests>
+
+  <help><![CDATA[
+===================================================================
+Perform PAGA (partition-based graph abstraction) (`scanpy.tl.paga`)
+===================================================================
+
+Infer trajectories by mapping out the coarse-grained connectivity structures of
+complex manifolds of single cell KNN graphs (Wolf et al, 2019).
+
+This requires to run `Scanpy FindCluster`, first.
+
+It yields `paga`, connectivity graph between clusters.
+
+@HELP@
+
+@VERSION_HISTORY@
+]]></help>
+  <expand macro="citations">
+    <citation type="doi">10.1186/s13059-019-1663-x</citation>
+  </expand>
+</tool>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tool id="scanpy_run_paga" name="Scanpy PAGA" version="@TOOL_VERSION@+galaxy0">
-  <description>based on community detection on KNN graph</description>
+  <description>trajectory inference</description>
   <macros>
     <import>scanpy_macros2.xml</import>
   </macros>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
@@ -29,7 +29,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli paga
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Cluster object"/>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: PAGA object"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
@@ -72,10 +72,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-pca
       <param name="svd_solver" value="arpack"/>
       <param name="random_seed" value="0"/>
       <param name="chunked" value="false"/>
-      <param name="plot" value="true"/>
-      <param name="color_by" value="n_genes"/>
       <output name="output_h5" file="run_pca.h5" ftype="h5" compare="sim_size"/>
-      <output name="output_png" file="run_pca.png" ftype="png" compare="sim_size"/>
       <output name="output_embed" file="run_pca.embeddings.csv" ftype="csv" compare="sim_size">
         <assert_contents>
           <has_n_columns n="50" sep=","/>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
@@ -1,93 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_pca" name="Scanpy RunPCA" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_run_pca" name="Scanpy RunPCA" version="@TOOL_VERSION@+galaxy0">
   <description>for dimensionality reduction</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-run-pca.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    -n '${n_pcs}'
-    #if $run_mode.chunked
-        -c
-        --chunk-size '${run_mode.chunk_size}'
-    #else
-        #if $run_mode.zero_center
-            -z
-        #else
-            -Z
-        #end if
-        #if $run_mode.svd_solver
-            --svd-solver '${run_mode.svd_solver}'
-        #end if
-        #if $run_mode.random_seed is not None
-            -s '${run_mode.random_seed}'
-        #end if
+PYTHONIOENCODING=utf-8 scanpy-run-pca
+    --n-comps '${n_pcs}'
+#if $run_mode.chunked
+    --chunked
+    --chunk-size '${run_mode.chunk_size}'
+#else
+    ${run_mode.zero_center}
+    #if $run_mode.svd_solver
+        --svd-solver '${run_mode.svd_solver}'
     #end if
-    #if $extra_outputs:
-        #set extras = ' '.join(['--output-{}-file {}.csv'.format(x, x) for x in str($extra_outputs).split(',')])
-        ${extras}
+    #if $run_mode.random_seed is not None
+        --random-state '${run_mode.random_seed}'
     #end if
-
-@PLOT_OPTS@
+#end if
+#if $extra_outputs and "embeddings" in str($extra_outputs).split(','):
+    --export-embedding embeddings.tsv
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
-    <param name="n_pcs" argument="--n-pcs" type="integer" value="50" label="Number of PCs to produce"/>
+    <param name="n_pcs" argument="--n-comps" type="integer" min="2" value="50" label="Number of PCs to produce"/>
     <conditional name="run_mode">
       <param name="chunked" argument="--chunked" type="boolean" checked="false" label="Perform incremental PCA by chunks"/>
       <when value="true">
         <param name="chunk_size" argument="--chunk-size" type="integer" value="0" label="Chunk size"/>
       </when>
       <when value="false">
-        <param name="zero_center" argument="--zero-center" type="boolean" checked="true" label="Zero center data before scaling"/>
+        <param name="zero_center" argument="--zero-center" type="boolean" truevalue="" falsevalue="--no-zero-center" checked="true"
+               label="Zero center data before scaling"/>
         <param name="svd_solver" argument="--svd-solver" type="select" optional="true" label="SVD solver">
           <option value="arpack">ARPACK</option>
-          <option value="randomised">Randomised</option>
+          <option value="randomized">Randomised</option>
         </param>
-        <param name="random_seed" argument="--random-seed" type="integer" value="0" label="random_seed for numpy random number generator"/>
+        <param name="random_seed" argument="--random-state" type="integer" value="0" label="random seed for numpy random number generator"/>
       </when>
     </conditional>
 
-    <param name="extra_outputs" type="select" multiple="true" optional="true" label="Type of output">
+    <param name="extra_outputs" type="select" multiple="true" display="checkboxes" optional="true" label="Export extra output">
       <option value="embeddings">PCA embeddings</option>
-      <option value="loadings">PCA loadings</option>
-      <option value="stdev">PCs stdev</option>
-      <option value="var-ratio">PCs proportion of variance</option>
     </param>
 
-    <conditional name="do_plotting">
-      <param name="plot" type="boolean" checked="false" label="Make PCA plot"/>
-      <when value="true">
-        <expand macro="output_plot_params"/>
-      </when>
-      <when value="false"/>
-    </conditional>
   </inputs>
 
   <outputs>
     <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: PCA object"/>
-    <data name="output_png" format="png" from_work_dir="output.png" label="${tool.name} on ${on_string}: PCA plot">
-      <filter>do_plotting['plot']</filter>
-    </data>
-    <data name="output_embed" format="csv" from_work_dir="embeddings.csv" label="${tool.name} on ${on_string}: PCA embeddings">
+    <data name="output_embed" format="tsv" from_work_dir="embeddings.tsv" label="${tool.name} on ${on_string}: PCA embeddings">
       <filter>extra_outputs and 'embeddings' in extra_outputs.split(',')</filter>
-    </data>
-    <data name="output_load" format="csv" from_work_dir="loadings.csv" label="${tool.name} on ${on_string}: PCA loadings">
-      <filter>extra_outputs and 'loadings' in extra_outputs.split(',')</filter>
-    </data>
-    <data name="output_stdev" format="csv" from_work_dir="stdev.csv" label="${tool.name} on ${on_string}: PCA stdev">
-      <filter>extra_outputs and 'stdev' in extra_outputs.split(',')</filter>
-    </data>
-    <data name="output_vprop" format="csv" from_work_dir="var-ratio.csv" label="${tool.name} on ${on_string}: PC explained proportion of variance">
-      <filter>extra_outputs and 'var-ratio' in extra_outputs.split(',')</filter>
     </data>
   </outputs>
 
@@ -115,9 +85,9 @@ PYTHONIOENCODING=utf-8 scanpy-run-pca.py
   </tests>
 
   <help><![CDATA[
-=======================================================================================================
-Computes PCA (principal component analysis) coordinates, loadings and variance decomposition (`tl.pca`)
-=======================================================================================================
+================================================================================
+Dimensionality reduction by PCA (principal component analysis) (`scanpy.pp.pca`)
+================================================================================
 
 It uses the implementation of *scikit-learn*.
 

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -102,7 +102,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
 t-distributed stochastic neighborhood embedding (tSNE) (`scanpy.tl.tsne`)
 =========================================================================
 
-For making TSNE plots, please use `Scanpy PlotEmbed` and enter "tsne" as the
+For making TSNE plots, please use `Scanpy PlotEmbed` with the output of this tool and enter "tsne" as the
 name of the embedding to plot.
 
 t-distributed stochastic neighborhood embedding (tSNE) (Maaten et al, 2008) has been

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -98,9 +98,12 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
   </tests>
 
   <help><![CDATA[
-==================================================================
-t-distributed stochastic neighborhood embedding (tSNE) (`tl.tsne`)
-==================================================================
+=========================================================================
+t-distributed stochastic neighborhood embedding (tSNE) (`scanpy.tl.tsne`)
+=========================================================================
+
+For making TSNE plots, please use `Scanpy PlotEmbed` and enter "tsne" as the
+name of the embedding to plot.
 
 t-distributed stochastic neighborhood embedding (tSNE) (Maaten et al, 2008) has been
 proposed for visualizating single-cell data by (Amir et al, 2013). Here, by default,

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -2,45 +2,45 @@
 <tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy1">
   <description>visualise cell clusters using tSNE</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-run-tsne.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    #if $embeddings
-        --output-embeddings-file embeddings.csv
+PYTHONIOENCODING=utf-8 scanpy-run-tsne
+#if $use_rep != "auto"
+    --use-rep '${use_rep}'
+#end if
+#if $key_added
+    --key-added '${key_added}'
+#end if
+#if $embeddings
+    --export-embedding embeddings.csv
+#end if
+#if $settings.default == "false"
+    #if $settings.perplexity_file
+        --perplexity \$( cat $settings.perplexity_file )
+    #else
+        --perplexity '${settings.perplexity}'
     #end if
-    #if $settings.default == "false"
-        #if $settings.perplexity_file
-          --perplexity \$( cat $settings.perplexity_file )
-        #else
-          --perplexity '${settings.perplexity}'
-        #end if
-        --early-exaggeration '${settings.early_exaggeration}'
-        --learning-rate '${settings.learning_rate}'
-        #if $settings.use_rep != "auto"
-            -r '${settings.use_rep}'
-        #end if
-        #if $settings.n_pc
-            -n '${settings.n_pc}'
-        #end if
-        #if not $settings.fast_tsne
-            --no-fast-tsne
-        #end if
-        #if $settings.n_job
-            --n-jobs '${settings.n_job}'
-        #end if
-        #if $settings.random_seed is not None
-            -s '${settings.random_seed}'
-        #end if
+    --early-exaggeration '${settings.early_exaggeration}'
+    --learning-rate '${settings.learning_rate}'
+    #if $settings.n_pc
+        --n-pcs ${settings.n_pc}
     #end if
+    #if not $settings.fast_tsne
+        --no-fast-tsne
+    #end if
+    #if $settings.n_job
+        --n-jobs ${settings.n_job}
+    #end if
+    #if $settings.random_seed is not None
+        --random-state ${settings.random_seed}
+    #end if
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 
-@PLOT_OPTS@
 ]]></command>
 
   <inputs>
@@ -48,15 +48,18 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne.py
     <expand macro="output_object_params"/>
     <param name="embeddings" type="boolean" checked="true" label="Output embeddings in csv format"/>
 
+    <param name="use_rep" argument="--use-rep" type="select" label="Use the indicated representation">
+      <option value="X_pca">X_pca, use PCs</option>
+      <option value="X">X, use normalised expression values</option>
+      <option value="auto" selected="true">Automatically chosen based on problem size</option>
+    </param>
+    <param name="key_added" argument="--key-added" type="text" optional="true"
+           label="Additional suffix to the name of the slot to save the embedding"/>
+
     <conditional name="settings">
       <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
       <when value="true"/>
       <when value="false">
-        <param name="use_rep" argument="--use-rep" type="select" label="Use the indicated representation">
-          <option value="X_pca">X_pca, use PCs</option>
-          <option value="X">X, use normalised expression values</option>
-          <option value="auto" selected="true">Automatically chosen based on problem size</option>
-        </param>
         <param name="perplexity" argument="--perplexity" type="float" value="30" label="The perplexity is related to the number of nearest neighbours, select a value between 5 and 50"/>
         <param name="perplexity_file" argument="--perplexity" type="data" format="txt,tsv" label="The perplexity is related to the number of nearest neighbours" help="For use with the parameter iterator. Overrides the persplexity option above" optional="true"/>
         <param name="early_exaggeration" argument="--early-exaggeration" type="float" value="12" label="Controls the tightness within and between clusters"/>
@@ -68,21 +71,10 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne.py
       </when>
     </conditional>
 
-    <conditional name="do_plotting">
-      <param name="plot" type="boolean" checked="false" label="Make tSNE plot"/>
-      <when value="true">
-        <expand macro="output_plot_params"/>
-        <param name="color_by" argument="--color-by" type="text" value="louvain" label="Color by attributes, comma separated strings"/>
-      </when>
-      <when value="false"/>
-    </conditional>
   </inputs>
 
   <outputs>
     <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: tSNE object"/>
-    <data name="output_png" format="png" from_work_dir="output.png" label="${tool.name} on ${on_string}: tSNE plot">
-      <filter>do_plotting['plot']</filter>
-    </data>
     <data name="output_embed" format="csv" from_work_dir="embeddings.csv" label="${tool.name} on ${on_string}: tSNE embeddings">
       <filter>embeddings</filter>
     </data>
@@ -96,10 +88,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne.py
       <param name="default" value="false"/>
       <param name="embeddings" value="true"/>
       <param name="random_seed" value="0"/>
-      <param name="plot" value="true"/>
-      <param name="color_by" value="louvain"/>
       <output name="output_h5" file="run_tsne.h5" ftype="h5" compare="sim_size"/>
-      <output name="output_png" file="run_tsne.png" ftype="png" compare="sim_size"/>
       <output name="output_embed" file="run_tsne.embeddings.csv" ftype="csv" compare="sim_size">
         <assert_contents>
           <has_n_columns n="2" sep=","/>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -2,50 +2,46 @@
 <tool id="scanpy_run_umap" name="Scanpy RunUMAP" version="@TOOL_VERSION@+galaxy1">
   <description>visualise cell clusters using UMAP</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-run-umap.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
-    #if $embeddings
-        --output-embeddings-file embeddings.csv
+PYTHONIOENCODING=utf-8 scanpy-run-umap
+    --use-graph '${use_graph}'
+    --key-added '${key_added}'
+#if $embeddings
+    --export-embedding embeddings.csv
+#end if
+#if $settings.default == "false"
+    --n-components ${settings.n_components}
+    --min-dist ${settings.min_dist}
+    --spread ${settings.spread}
+    --alpha ${settings.alpha}
+    --gamma ${settings.gamma}
+    --negative-sample-rate ${settings.negative_sample_rate}
+    --random-state ${settings.random_seed}
+    #if $settings.init_pos
+        --init-pos '${settings.init_pos}'
     #end if
-    #if $settings.default == "false"
-        -n '${settings.n_components}'
-        --min-dist '${settings.min_dist}'
-        --spread '${settings.spread}'
-        --alpha '${settings.alpha}'
-        --gamma '${settings.gamma}'
-        --negative-sample-rate '${settings.negative_sample_rate}'
-        #if $settings.init_pos
-            --init-pos '${settings.init_pos}'
-        #end if
-        #if $settings.maxiter
-            --maxiter '${settings.maxiter}'
-        #end if
-        #if $settings.a
-            -a '${settings.a}'
-        #end if
-        #if $settings.b
-            -b '${settings.b}'
-        #end if
-        #if $settings.random_seed is not None
-            -s '${settings.random_seed}'
-        #end if
-   #end if
+    #if $settings.maxiter
+        --maxiter ${settings.maxiter}
+    #end if
+#end if
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 
-@PLOT_OPTS@
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
     <param name="embeddings" type="boolean" checked="true" label="Output embeddings in csv format"/>
+    <param name="use_graph" argument="--use-graph" value="neighbors" type="text"
+           label="Name of the slot that holds the KNN graph"/>
+    <param name="key_added" argument="--key-added" type="text" optional="true"
+           label="Additional suffix to the name of the slot to save the embedding"/>
+
     <conditional name="settings">
       <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
       <when value="true"/>
@@ -62,26 +58,13 @@ PYTHONIOENCODING=utf-8 scanpy-run-umap.py
           <option value="random">random</option>
         </param>
         <param name="maxiter" argument="--maxiter" type="integer" optional="true" label="Number of iterations of optimisation"/>
-        <param name="a" argument="-a" type="float" optional="true" label="More specific parameter controlling embedding, automatically determined from --min-dist and --spread if unset"/>
-        <param name="b" argument="-b" type="float" optional="true" label="More specific parameter controlling embedding, automatically determined from --min-dist and --spread if unset"/>
-        <param name="random_seed" argument="--random-seed" type="integer" value="0" label="Seed for numpy random number generator"/>
+        <param name="random_seed" argument="--random-state" type="integer" value="0" label="Seed for numpy random number generator"/>
       </when>
-    </conditional>
-    <conditional name="do_plotting">
-      <param name="plot" type="boolean" checked="false" label="Make UMAP plot"/>
-      <when value="true">
-        <expand macro="output_plot_params"/>
-        <param name="color_by" argument="--color-by" type="text" value="louvain" label="Color by attributes, comma separated strings"/>
-      </when>
-      <when value="false"/>
     </conditional>
   </inputs>
 
   <outputs>
     <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: UMAP object"/>
-    <data name="output_png" format="png" from_work_dir="output.png" label="${tool.name} on ${on_string}: UMAP plot">
-      <filter>do_plotting['plot']</filter>
-    </data>
     <data name="output_embed" format="csv" from_work_dir="embeddings.csv" label="${tool.name} on ${on_string}: UMAP embeddings">
       <filter>embeddings</filter>
     </data>
@@ -95,10 +78,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-umap.py
       <param name="default" value="false"/>
       <param name="embeddings" value="true"/>
       <param name="random_seed" value="0"/>
-      <param name="plot" value="true"/>
-      <param name="color_by" value="louvain"/>
       <output name="output_h5" file="run_umap.h5" ftype="h5" compare="sim_size"/>
-      <output name="output_png" file="run_umap.png" ftype="png" compare="sim_size"/>
       <output name="output_embed" file="run_umap.embeddings.csv" ftype="csv" compare="sim_size">
         <assert_contents>
           <has_n_columns n="2" sep=","/>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -92,7 +92,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-umap
 Embed the neighborhood graph using UMAP (`scanpy.tl.umap`)
 ==========================================================
 
-For making UMAP plots, please use `Scanpy PlotEmbed` and enter "umap" as the
+For making UMAP plots, please use `Scanpy PlotEmbed` with the output of this tool and enter "umap" as the
 name of the embedding to plot.
 
 UMAP (Uniform Manifold Approximation and Projection) is a manifold learning

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -88,9 +88,12 @@ PYTHONIOENCODING=utf-8 scanpy-run-umap
   </tests>
 
   <help><![CDATA[
-========================================================
-Embed the neighborhood graph using UMAP (`tl.umap`)
-========================================================
+==========================================================
+Embed the neighborhood graph using UMAP (`scanpy.tl.umap`)
+==========================================================
+
+For making UMAP plots, please use `Scanpy PlotEmbed` and enter "umap" as the
+name of the embedding to plot.
 
 UMAP (Uniform Manifold Approximation and Projection) is a manifold learning
 technique suitable for visualizing high-dimensional data. Besides tending to

--- a/tools/tertiary-analysis/scanpy/scanpy-scale-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-scale-data.xml
@@ -1,40 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_scale_data" name="Scanpy ScaleData" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_scale_data" name="Scanpy ScaleData" version="@TOOL_VERSION@+galaxy0">
   <description>to make expression variance the same for all genes</description>
   <macros>
-    <import>scanpy_macros.xml</import>
+    <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
-PYTHONIOENCODING=utf-8 scanpy-scale-data.py
-    -i input.h5
-    -f '${input_format}'
-    -o output.h5
-    -F '${output_format}'
+PYTHONIOENCODING=utf-8 scanpy-scale-data
     #if $scale_max
-        -x '${scale_max}'
+        --max-value '${scale_max}'
     #end if
-    #if $var_to_regress
-        -V '${var_to_regress}'
-    #end if
-    #if $do_log
-        --do-log
-    #end if
-    #if $zero_center
-        --zero-center
-    #end if
+    ${zero_center}
+    @INPUT_OPTS@
+    @OUTPUT_OPTS@
 ]]></command>
 
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
-    <param name="do_log" argument="--do-log" type="boolean" checked="true" label="Do log(x+1) transformation"/>
-    <param name="zero_center" argument="--zero-center" type="boolean" checked="true" label="Zero center data before scaling"/>
-    <param name="var_to_regress" argument="--var-to-regress" type="text" optional="true" label="Variable(s) to regress out">
-      <option value="n_counts">n_counts</option>
-    </param>
-    <param name="scale_max" argument="--scale-max" type="float" optional="true" label="Truncate to this value after scaling"/>
+    <param name="zero_center" type="boolean" checked="true" truevalue="" falsevalue="--no-zero-center"
+           label="Zero center data before scaling"/>
+    <param name="scale_max" argument="--max-value" type="float" min="0" optional="true" label="Truncate to this value after scaling"/>
   </inputs>
 
   <outputs>
@@ -46,7 +33,6 @@ PYTHONIOENCODING=utf-8 scanpy-scale-data.py
       <param name="input_obj_file" value="find_variable_genes.h5"/>
       <param name="input_format" value="anndata"/>
       <param name="output_format" value="anndata"/>
-      <param name="do_log" value="true"/>
       <param name="zero_center" value="true"/>
       <param name="scale_max" value="10"/>
       <output name="output_h5" file="scale_data.h5" ftype="h5" compare="sim_size"/>
@@ -58,11 +44,7 @@ PYTHONIOENCODING=utf-8 scanpy-scale-data.py
 
     **What it does**
 
-    Scale data to unit variance and zero mean (`pp.scale`)
-    Regress out unwanted sources of variation (`pp.regress_out`)
-
-    Regress out unwanted sources of variation, using simple linear regression. This is
-    inspired by Seurat's `regressOut` function in R.
+    Scale data to unit variance and (optionally) zero mean (`scanpy.pp.scale`)
 
     @HELP@
 

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -17,6 +17,17 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
   <token name="@OUTPUT_OPTS@">
     --show-obj stdout --output-format '${output_format}' output.h5
   </token>
+  <token name="@PLOT_OPTS@">
+    --basis '${basis}'
+    --color '${color_by}'
+    ${use_raw}
+    --legend-loc '${legend_loc}'
+    --legend-fontsize '${legend_fontsize}'
+    --fig-size '${fig_size}'
+    --fig-dpi '${fig_dpi}'
+    --fig-fontsize '${fig_fontsize}'
+    output.png
+  </token>
   <token name="@EXPORT_MTX_OPTS@">${export_mtx}</token>
 
   <xml name="requirements">
@@ -60,13 +71,15 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
   <xml name="output_plot_params">
     <param name="basis" argument="--basis" type="text" label="Name of the embedding to plot"/>
     <param name="color_by" argument="--color" type="text" label="Color by attributes, comma separated texts"/>
-    <param name="use_raw" argument="--use-raw" type="boolean" checked="false" truevalue="--use-raw" falsevalue="--no-raw" label="Use raw attributes if present"/>
+    <param name="use_raw" argument="--use-raw" type="boolean" checked="true" truevalue="--use-raw" falsevalue="--no-raw" label="Use raw attributes if present"/>
     <param name="legend_loc" argument="--legend-loc" type="select" label="Location of legend">
       <option value="right margin" selected="true">Right margin</option>
       <option value="on data">On data</option>
     </param>
     <param name="legend_fontsize" argument="--legend-fontsize" type="integer" value="15" label="Legend font size"/>
     <param name="fig_size" argument="--fig-size" type="text" value="7,7" label="Figure size as 'width,height', e.g, '7,7'"/>
+    <param name="fig_dpi" argument="--fig-dpi" type="integer" value="80" label="Figure dpi"/>
+    <param name="fig_fontsize" argument="--fig-fontsize" type="integer" value="10" label="Figure font size"/>
   </xml>
 
   <xml name="export_mtx_params">

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -1,0 +1,86 @@
+<macros>
+  <token name="@TOOL_VERSION@">1.4.2</token>
+  <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
+  <token name="@VERSION_HISTORY@"><![CDATA[
+**Version history**
+1.4.2+galaxy0: Update to scanpy-scripts 0.2.2 (requires scanpy >=1.4.2).
+
+1.3.2+galaxy1: Normalise-data and filter-genes: Exposes ability to output 10x files.
+
+1.3.2+galaxy0: Initial contribution. Ni Huang and Pablo Moreno, Expression Atlas team https://www.ebi.ac.uk/gxa/home  at
+EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
+    ]]></token>
+  <token name="@INPUT_OPTS@">
+    --input-format '${input_format}' input.h5
+  </token>
+  <token name="@OUTPUT_OPTS@">
+    --show-obj stdout --output-format '${output_format}' output.h5
+  </token>
+  <token name="@EXPORT_MTX_OPTS@">${export_mtx}</token>
+
+  <xml name="requirements">
+    <requirements>
+      <requirement type="package" version="0.2.2">scanpy-scripts</requirement>
+      <yield/>
+    </requirements>
+  </xml>
+
+  <xml name="citations">
+    <citations>
+      <citation type="doi">10.1186/s13059-017-1382-0</citation>
+      <citation type="bibtex">
+	@misc{githubscanpy-scripts,
+	author = {Ni Huang, EBI Gene Expression Team},
+	year = {2018},
+	title = {Scanpy-scripts: command line interface for Scanpy},
+	publisher = {GitHub},
+	journal = {GitHub repository},
+	url = {https://github.com/ebi-gene-expression-group/scanpy-scripts},
+      }</citation>
+      <yield />
+    </citations>
+  </xml>
+
+  <xml name="input_object_params">
+    <param name="input_obj_file" argument="input-object-file" type="data" format="h5" label="Input object in hdf5 format"/>
+    <param name="input_format" argument="--input-format" type="select" label="Format of input object">
+      <option value="anndata" selected="true">AnnData format hdf5</option>
+      <option value="loom">Loom format hdf5</option>
+    </param>
+  </xml>
+
+  <xml name="output_object_params">
+    <param name="output_format" argument="--output-format" type="select" label="Format of output object">
+      <option value="anndata" selected="true">AnnData format hdf5</option>
+      <option value="loom">Loom format hdf5</option>
+    </param>
+  </xml>
+
+  <xml name="output_plot_params">
+    <param name="basis" argument="--basis" type="text" label="Name of the embedding to plot"/>
+    <param name="color_by" argument="--color" type="text" label="Color by attributes, comma separated texts"/>
+    <param name="use_raw" argument="--use-raw" type="boolean" checked="false" truevalue="--use-raw" falsevalue="--no-raw" label="Use raw attributes if present"/>
+    <param name="legend_loc" argument="--legend-loc" type="select" label="Location of legend">
+      <option value="right margin" selected="true">Right margin</option>
+      <option value="on data">On data</option>
+    </param>
+    <param name="legend_fontsize" argument="--legend-fontsize" type="integer" value="15" label="Legend font size"/>
+    <param name="fig_size" argument="--fig-size" type="text" value="7,7" label="Figure size as 'width,height', e.g, '7,7'"/>
+  </xml>
+
+  <xml name="export_mtx_params">
+    <param name="export_mtx" argument="--export-mtx" type="boolean" truevalue="--export-mtx ./" falsevalue="" checked="false" label="Save normalised data to 10x format" help="If enabled, it will generate in addition to the main output in Loom or AnnData an export in 10x format of the normalised data."/>
+  </xml>
+
+  <xml name="export_mtx_outputs">
+    <data name="matrix_10x" format="txt" from_work_dir="matrix.mtx" label="${tool.name} on ${on_string}: 10x matrix">
+      <filter>export_mtx</filter>
+    </data>
+    <data name="genes_10x" format="tsv" from_work_dir="genes.tsv" label="${tool.name} on ${on_string}: 10x genes">
+      <filter>export_mtx</filter>
+    </data>
+    <data name="barcodes_10x" format="tsv" from_work_dir="barcodes.tsv" label="${tool.name} on ${on_string}: 10x barcodes">
+      <filter>export_mtx</filter>
+    </data>
+  </xml>
+</macros>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -31,7 +31,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.2.4.post1">scanpy-scripts</requirement>
+      <requirement type="package" version="0.2.4.post4">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -4,7 +4,7 @@
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
 
-1.4.2+galaxy0: Update to scanpy-scripts 0.2.2 (requires scanpy >=1.4.2).
+1.4.2+galaxy0: Update to scanpy-scripts 0.2.4 (requires scanpy >=1.4.2).
 
 1.3.2+galaxy1: Normalise-data and filter-genes: Exposes ability to output 10x files.
 
@@ -18,21 +18,18 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
     --show-obj stdout --output-format '${output_format}' output.h5
   </token>
   <token name="@PLOT_OPTS@">
-    --basis '${basis}'
-    --color '${color_by}'
-    ${use_raw}
-    --legend-loc '${legend_loc}'
-    --legend-fontsize '${legend_fontsize}'
+    --title '${fig_title}'
     --fig-size '${fig_size}'
-    --fig-dpi '${fig_dpi}'
-    --fig-fontsize '${fig_fontsize}'
-    output.png
+    --fig-dpi ${fig_dpi}
+    --fig-fontsize ${fig_fontsize}
+    ${fig_frame}
+    ./output.png
   </token>
   <token name="@EXPORT_MTX_OPTS@">${export_mtx}</token>
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.2.2">scanpy-scripts</requirement>
+      <requirement type="package" version="0.2.4">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>
@@ -69,21 +66,16 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
   </xml>
 
   <xml name="output_plot_params">
-    <param name="basis" argument="--basis" type="text" label="Name of the embedding to plot"/>
-    <param name="color_by" argument="--color" type="text" label="Color by attributes, comma separated texts"/>
-    <param name="use_raw" argument="--use-raw" type="boolean" checked="true" truevalue="--use-raw" falsevalue="--no-raw" label="Use raw attributes if present"/>
-    <param name="legend_loc" argument="--legend-loc" type="select" label="Location of legend">
-      <option value="right margin" selected="true">Right margin</option>
-      <option value="on data">On data</option>
-    </param>
-    <param name="legend_fontsize" argument="--legend-fontsize" type="integer" value="15" label="Legend font size"/>
+    <param name="fig_title" argument="--title" type="text" label="Figure title"/>
     <param name="fig_size" argument="--fig-size" type="text" value="4,4" label="Figure size as 'width,height', e.g, '7,7'"/>
-    <param name="fig_dpi" argument="--fig-dpi" type="integer" value="80" label="Figure dpi"/>
-    <param name="fig_fontsize" argument="--fig-fontsize" type="integer" value="10" label="Figure font size"/>
+    <param name="fig_dpi" argument="--fig-dpi" type="integer" min="1" value="80" label="Figure dpi"/>
+    <param name="fig_fontsize" argument="--fig-fontsize" type="integer" min="0" value="10" label="Figure font size"/>
+    <param name="fig_frame" type="boolean" truevalue="--frameon" falsevalue="--frameoff" checked="false"
+           label="Show plot frame"/>
   </xml>
 
   <xml name="export_mtx_params">
-    <param name="export_mtx" argument="--export-mtx" type="boolean" truevalue="--export-mtx ./" falsevalue="" checked="false" label="Save normalised data to 10x format" help="If enabled, it will generate in addition to the main output in Loom or AnnData an export in 10x format of the normalised data."/>
+    <param name="export_mtx" argument="--export-mtx" type="boolean" truevalue="--export-mtx ./" falsevalue="" checked="false" label="Save normalised data to 10x mtx format" help="If enabled, it will generate in addition to the main output in Loom or AnnData an export in 10x format of the normalised data."/>
   </xml>
 
   <xml name="export_mtx_outputs">

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">1.4.2</token>
+  <token name="@TOOL_VERSION@">1.4.2.post1</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">1.4.2.post1</token>
+  <token name="@TOOL_VERSION@">1.4.2</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
@@ -18,7 +18,9 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
     --show-obj stdout --output-format '${output_format}' output.h5
   </token>
   <token name="@PLOT_OPTS@">
+#if $fig_title
     --title '${fig_title}'
+#end if
     --fig-size '${fig_size}'
     --fig-dpi ${fig_dpi}
     --fig-fontsize ${fig_fontsize}
@@ -29,7 +31,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.2.4">scanpy-scripts</requirement>
+      <requirement type="package" version="0.2.4.post1">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -77,7 +77,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
       <option value="on data">On data</option>
     </param>
     <param name="legend_fontsize" argument="--legend-fontsize" type="integer" value="15" label="Legend font size"/>
-    <param name="fig_size" argument="--fig-size" type="text" value="7,7" label="Figure size as 'width,height', e.g, '7,7'"/>
+    <param name="fig_size" argument="--fig-size" type="text" value="4,4" label="Figure size as 'width,height', e.g, '7,7'"/>
     <param name="fig_dpi" argument="--fig-dpi" type="integer" value="80" label="Figure dpi"/>
     <param name="fig_fontsize" argument="--fig-fontsize" type="integer" value="10" label="Figure font size"/>
   </xml>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -3,6 +3,7 @@
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
+
 1.4.2+galaxy0: Update to scanpy-scripts 0.2.2 (requires scanpy >=1.4.2).
 
 1.3.2+galaxy1: Normalise-data and filter-genes: Exposes ability to output 10x files.
@@ -27,6 +28,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="citations">
     <citations>
+      <yield />
       <citation type="doi">10.1186/s13059-017-1382-0</citation>
       <citation type="bibtex">
 	@misc{githubscanpy-scripts,
@@ -37,7 +39,6 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 	journal = {GitHub repository},
 	url = {https://github.com/ebi-gene-expression-group/scanpy-scripts},
       }</citation>
-      <yield />
     </citations>
   </xml>
 


### PR DESCRIPTION
This PR adds/updates certain scanpy wrappers to use scanpy-scripts 0.2.x.

`read-10x`: updated to allow adding gene/cell meta data.
`filter-cell`: updated to allow specifying MT genes and filter based on MT content.
`normalise-data`: updated to allow the exclusion of the influence from top expressed genes.
`find-variable-genes`: updated to allow marking rather than filtering variable genes.
`regress-variable`: added as standalone step.
`scale-data`: updated to spin-out `regress-variable`.
`find-cluster`: updated to allow choosing different algorithm.
`find-markers`: updated to allow filtering tested genes.
`run-paga`: added to for trajectory inference.
`run-diffmap`, `run-dpt`: added for pseudo-time inference.
`plot-embedding`: added as a standalone plotting function.
`plot-trajectory`: added as a standalone plotting function.
The rest (`filter-gene`, `run-pca`, `neighbors`, `run-umap`, `run-tsne`): updated to scanpy-scripts 0.2.x.