### PR TITLE
Bump cellbrowser 0.5.43

### DIFF
--- a/tools/tertiary-analysis/data-scxa/retrieve-scxa.xml
+++ b/tools/tertiary-analysis/data-scxa/retrieve-scxa.xml
@@ -19,7 +19,8 @@ cut -f2 '${accession}'.expression_tpm.mtx_cols > ${barcode_tsv};
 
 wget -O ${matrix_mtx} 'ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/${accession}/${accession}.aggregated_filtered_counts.mtx';
 wget -qO - 'ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/${accession}/${accession}.aggregated_filtered_counts.mtx_cols' | cut -f2 > ${barcode_tsv};
-wget -qO - 'ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/${accession}/${accession}.aggregated_filtered_counts.decorated.mtx_rows' > ${genes_tsv};
+wget -qO - 'ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/${accession}/${accession}.aggregated_filtered_counts.decorated.mtx_rows' |
+  awk -F'\t' '{ if (length($2) == 0) { print $1"\t"$1 } else { print $0 } }' > ${genes_tsv};
 
 #end if
 

--- a/tools/tertiary-analysis/data-scxa/retrieve-scxa.xml
+++ b/tools/tertiary-analysis/data-scxa/retrieve-scxa.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="retrieve_scxa" name="EBI SCXA Data Retrieval" version="v0.0.1+galaxy2">
+<tool id="retrieve_scxa" name="EBI SCXA Data Retrieval" version="v0.0.2+galaxy2">
   <description>Retrieves expression matrixes and metadata from EBI Single Cell Expression Atlas (SCXA)</description>
   <requirements>
     <requirement type="package" version="1.20.1">wget</requirement>
@@ -19,8 +19,7 @@ cut -f2 '${accession}'.expression_tpm.mtx_cols > ${barcode_tsv};
 
 wget -O ${matrix_mtx} 'ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/${accession}/${accession}.aggregated_filtered_counts.mtx';
 wget -qO - 'ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/${accession}/${accession}.aggregated_filtered_counts.mtx_cols' | cut -f2 > ${barcode_tsv};
-wget -qO - 'ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/${accession}/${accession}.aggregated_filtered_counts.mtx_rows'
- | awk '{OFS="\t"; print \$2,\$2}' > ${genes_tsv};
+wget -qO - 'ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/${accession}/${accession}.aggregated_filtered_counts.decorated.mtx_rows' > ${genes_tsv};
 
 #end if
 
@@ -88,6 +87,7 @@ matrix that you want to download:
   already normalized/scaled. You should keep this in mind when using this data
   on methods that will try to normalise data as part of their procedure. Due to technical
   particularities in the current Atlas SC pipeline, TPMs available here are not filtered.
+  **Note: droplet databases won't have TPM data**
 
 Outputs will be:
 

--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -1,7 +1,7 @@
-<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.5.21+galaxy0">
+<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.5.37+galaxy0">
   <description>displays single-cell clusterized data in an interactive web application.</description>
   <requirements>
-    <requirement type="package" version="0.5.21">ucsc-cell-browser</requirement>
+    <requirement type="package" version="0.5.37">ucsc-cell-browser</requirement>
   </requirements>
 <stdio>
 <exit_code range="1:" />

--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -1,7 +1,7 @@
-<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.5.37+galaxy0">
+<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.5.43+galaxy0">
   <description>displays single-cell clusterized data in an interactive web application.</description>
   <requirements>
-    <requirement type="package" version="0.5.37">ucsc-cell-browser</requirement>
+    <requirement type="package" version="0.5.43">ucsc-cell-browser</requirement>
   </requirements>
 <stdio>
 <exit_code range="1:" />
@@ -100,6 +100,9 @@ EMBL-EBI https://www.ebi.ac.uk/.
 EMBL-EBI https://www.ebi.ac.uk/.
 
 0.5.21+galaxy0: Update UCSC CellBrowser version to 0.5.21. Pablo Moreno, Expression Atlas team https://www.ebi.ac.uk/gxa/home  at
+EMBL-EBI https://www.ebi.ac.uk/.
+
+0.5.38+galaxy0: Update UCSC CellBrowser version to 0.5.43. Fixes bugs and improves usage of gene symbols in AnnData objects. Pablo Moreno, Expression Atlas team https://www.ebi.ac.uk/gxa/home  at
 EMBL-EBI https://www.ebi.ac.uk/.
 ]]></help>
 <citations>


### PR DESCRIPTION
This PR:

- Moves Galaxy wrapper to UCSC CellBrowser 0.5.43, tested with the Scanpy and Seurat pipelines. The biggest improvement on our side for this is to finally be able to see gene symbols within CellBrowser.
- Incorporate changes for the EBI SCXA Downloader to get the new decorated gene lists (with gene symbols). Tested to work well with both Seurat and Scanpy pipelines (with CellBrowser showing the gene symbols).