### PR TITLE
Add sceasy

### DIFF
--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -142,6 +142,9 @@
     <tool file="tertiary-analysis/data-scxa/retrieve-scxa.xml"/>
     <tool file="tertiary-analysis/data-hca/matrix-service.xml"/>
   </section>
+  <section name="SCEasy" id="sceasy-tools">
+    <tool file="tertiary-analysis/sceasy/sceasy_convert.xml" labels="I/O"/>
+  </section>
   <section name="Seurat" id="seurat-tools">
     <tool file="tertiary-analysis/seurat/seurat_read10x.xml"  labels="I/O"/>
     <tool file="tertiary-analysis/seurat/seurat_create_object.xml"/>
@@ -206,7 +209,7 @@
     <tool file="tertiary-analysis/monocle3/monocle3-orderCells.xml"/>
     <tool file="tertiary-analysis/monocle3/monocle3-diffExp.xml"/>
   </section>
-  <section name='scmap' id='scmap-tools'>
+  <section name="scmap" id="scmap-tools">
     <tool file="tertiary-analysis/scmap/scmap_select_features.xml" />
     <tool file="tertiary-analysis/scmap/scmap_index_cluster.xml" />
     <tool file="tertiary-analysis/scmap/scmap_scmap_cluster.xml" />

--- a/tools/tertiary-analysis/sceasy/.shed.yml
+++ b/tools/tertiary-analysis/sceasy/.shed.yml
@@ -1,0 +1,17 @@
+categories:
+ - Transcriptomics
+description: "Convert scRNA data object between popular formats"
+long_description: |
+        Support the conversion between Loom <-> SingleCellExperiment (full), SingleCellExperiment -> AnnData (matrix, metadata, reducedDim) and Seurat -> AnnData (matrix, metadata, reducedDim).
+name: "sceasy"
+owner: ebi-gxa
+remote_repository_url: https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/
+type: unrestricted
+auto_tool_repositories:
+  name_template: "{{ tool_id }}"
+  description_template: "Wrapper for the SCEasy tool: {{ tool_name }}"
+suite:
+  name: "suite_sceasy"
+  description: "Convert scRNA data object between popular formats"
+  long_description: |
+        Support the conversion between Loom <-> SingleCellExperiment (full), SingleCellExperiment -> AnnData (matrix, metadata, reducedDim) and Seurat -> AnnData (matrix, metadata, reducedDim).

--- a/tools/tertiary-analysis/sceasy/sceasy_convert.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_convert.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tool id="sceasy_convert" name="SCEasy convert" version="@TOOL_VERSION@+galaxy0">
+  <description>a data object between formats</description>
+  <macros>
+    <import>sceasy_macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="exit_code"><![CDATA[
+#if str($conversion['direction']).startswith("loom")
+    ln -s ${conversion.input_object_file} input.h5 &&
+#else if str($conversion['direction']).startswith("anndata")
+    ln -s ${conversion.input_object_file} input.h5ad &&
+#else
+    ln -s ${conversion.input_object_file} input.rds &&
+#end if
+
+    Rscript -e 'library(sceasy)'
+#if $conversion.direction == "loom2sce"
+            -e 'sce <- sceasy::convertFormat("input.h5", from="loom", to="sce")'
+            -e 'saveRDS(sce, "output.rds")'
+#else if $conversion.direction == "sce2loom"
+            -e 'sce <- readRDS("input.rds")'
+            -e 'sceasy::convertFormat(sce, outFile="output.h5", from="sce", to="loom")'
+#else if $conversion.direction == "sce2anndata"
+            -e 'sce <- readRDS("input.rds")'
+            -e 'sceasy::convertFormat(sce, outFile="output.h5ad", from="sce", to="anndata")'
+#else if $conversion.direction == "seurat2anndata"
+            -e 'srt <- readRDS("input.rds")'
+            -e 'sceasy::convertFormat(srt, outFile="output.h5ad", from="seurat", to="anndata")'
+#end if
+]]></command>
+
+  <inputs>
+    <conditional name="conversion">
+      <param name="direction" type="select" label="Direction of conversion">
+        <option value="loom2sce" selected="true">Loom to SingleCellExperiment</option>
+        <option value="sce2loom">SingleCellExperiment to Loom</option>
+        <option value="seurat2anndata">Seurat to AnnData</option>
+        <option value="sce2anndata">SingleCellExperiment to AnnData</option>
+      </param>
+      <when value="loom2sce">
+        <param name="input_object_file" type="data" format="h5" label="Input object in Loom format"/>
+      </when>
+      <when value="sce2loom">
+        <param name="input_object_file" type="data" format="rdata" label="Input object in SingleCellExperiment RDS format"/>
+      </when>
+      <when value="sce2anndata">
+        <param name="input_object_file" type="data" format="rdata" label="Input object in SingleCellExperiment RDS format"/>
+      </when>
+      <when value="seurat2anndata">
+        <param name="input_object_file" type="data" format="rdata" label="Input object in Seurat RDS format"/>
+      </when>
+    </conditional>
+  </inputs>
+
+  <outputs>
+    <data name="output_sce" format="rdata" from_work_dir="output.rds" label="${tool.name} on ${on_string}: SingleCellExperiment">
+      <filter>conversion['direction'].endswith('sce')</filter>
+    </data>
+    <data name="output_loom" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Loom">
+      <filter>conversion['direction'].endswith('loom')</filter>
+    </data>
+    <data name="output_anndata" format="h5" from_work_dir="output.h5ad" label="${tool.name} on ${on_string}: AnnData">
+      <filter>conversion['direction'].endswith('anndata')</filter>
+    </data>
+  </outputs>
+
+  <tests>
+    <test>
+      <param name="direction" value="loom2sce"/>
+      <param name="input_object_file" value="input.loom"/>
+      <output name="output_sce" file="output.rds" ftype="rdata" compare="sim_size"/>
+    </test>
+  </tests>
+
+  <help><![CDATA[
+===================================================================
+Convert scRNA data object between formats `sceasy::convertFormat()`
+===================================================================
+
+Support the following conversion:
+ * Loom <-> SingleCellExperiment (full)
+ * SingleCellExperiment -> AnnData (matrix, metadata, reducedDim)
+ * Seurat -> AnnData (matrix, metadata, reducedDim)
+
+@HELP@
+
+@VERSION_HISTORY@
+]]></help>
+  <expand macro="citations"/>
+</tool>

--- a/tools/tertiary-analysis/sceasy/sceasy_convert.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_convert.xml
@@ -7,7 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 #if str($conversion['direction']).startswith("loom")
-    ln -s ${conversion.input_object_file} input.h5 &&
+    ln -s ${conversion.input_object_file} input.loom &&
 #else if str($conversion['direction']).startswith("anndata")
     ln -s ${conversion.input_object_file} input.h5ad &&
 #else
@@ -16,17 +16,20 @@
 
     Rscript -e 'library(sceasy)'
 #if $conversion.direction == "loom2sce"
-            -e 'sce <- sceasy::convertFormat("input.h5", from="loom", to="sce")'
+            -e 'sce <- sceasy::convertFormat("input.loom", from="loom", to="sce")'
             -e 'saveRDS(sce, "output.rds")'
+            -e 'print(sce)'
 #else if $conversion.direction == "sce2loom"
             -e 'sce <- readRDS("input.rds")'
-            -e 'sceasy::convertFormat(sce, outFile="output.h5", from="sce", to="loom")'
+            -e 'sceasy::convertFormat(sce, outFile="output.loom", from="sce", to="loom")'
 #else if $conversion.direction == "sce2anndata"
             -e 'sce <- readRDS("input.rds")'
             -e 'sceasy::convertFormat(sce, outFile="output.h5ad", from="sce", to="anndata")'
+            -e 'print(sce)'
 #else if $conversion.direction == "seurat2anndata"
             -e 'srt <- readRDS("input.rds")'
             -e 'sceasy::convertFormat(srt, outFile="output.h5ad", from="seurat", to="anndata")'
+            -e 'print(srt)'
 #end if
 ]]></command>
 
@@ -57,7 +60,7 @@
     <data name="output_sce" format="rdata" from_work_dir="output.rds" label="${tool.name} on ${on_string}: SingleCellExperiment">
       <filter>conversion['direction'].endswith('sce')</filter>
     </data>
-    <data name="output_loom" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Loom">
+    <data name="output_loom" format="h5" from_work_dir="output.loom" label="${tool.name} on ${on_string}: Loom">
       <filter>conversion['direction'].endswith('loom')</filter>
     </data>
     <data name="output_anndata" format="h5" from_work_dir="output.h5ad" label="${tool.name} on ${on_string}: AnnData">

--- a/tools/tertiary-analysis/sceasy/sceasy_convert.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_convert.xml
@@ -16,19 +16,19 @@
 
     Rscript -e 'library(sceasy)'
 #if $conversion.direction == "loom2sce"
-            -e 'sce <- sceasy::convertFormat("input.loom", from="loom", to="sce")'
+            -e 'sce <- sceasy::convertFormat("input.loom", from="loom", to="sce", main_layer_name="${assay_name}")'
             -e 'saveRDS(sce, "output.rds")'
             -e 'print(sce)'
 #else if $conversion.direction == "sce2loom"
             -e 'sce <- readRDS("input.rds")'
-            -e 'sceasy::convertFormat(sce, outFile="output.loom", from="sce", to="loom")'
+            -e 'sceasy::convertFormat(sce, outFile="output.loom", from="sce", to="loom", main_layer="${assay}")'
 #else if $conversion.direction == "sce2anndata"
             -e 'sce <- readRDS("input.rds")'
-            -e 'sceasy::convertFormat(sce, outFile="output.h5ad", from="sce", to="anndata")'
+            -e 'sceasy::convertFormat(sce, outFile="output.h5ad", from="sce", to="anndata", main_layer="${assay}")'
             -e 'print(sce)'
 #else if $conversion.direction == "seurat2anndata"
             -e 'srt <- readRDS("input.rds")'
-            -e 'sceasy::convertFormat(srt, outFile="output.h5ad", from="seurat", to="anndata")'
+            -e 'sceasy::convertFormat(srt, outFile="output.h5ad", from="seurat", to="anndata", assay="${assay}", main_layer="${dtype}")'
             -e 'print(srt)'
 #end if
 ]]></command>
@@ -43,15 +43,36 @@
       </param>
       <when value="loom2sce">
         <param name="input_object_file" type="data" format="h5" label="Input object in Loom format"/>
+        <param name="assay_name" type="text" label="Name of the expression matrix to be transferred as">
+          <option value="counts" selected="true">counts</option>
+          <option value="logcounts">logcounts</option>
+          <option value="cpm">cpm</option>
+        </param>
       </when>
       <when value="sce2loom">
         <param name="input_object_file" type="data" format="rdata" label="Input object in SingleCellExperiment RDS format"/>
+        <param name="assay" type="text" label="Name of the assay to be transferred as main layer" help="Please make sure the assay exists">
+          <option value="counts" selected="true">counts</option>
+          <option value="logcounts">logcounts</option>
+          <option value="cpm">cpm</option>
+        </param>
       </when>
       <when value="sce2anndata">
         <param name="input_object_file" type="data" format="rdata" label="Input object in SingleCellExperiment RDS format"/>
+        <param name="assay" type="text" label="Name of the assay to be transferred as main layer" help="Please make sure the assay exists">
+          <option value="counts" selected="true">counts</option>
+          <option value="logcounts">logcounts</option>
+          <option value="cpm">cpm</option>
+        </param>
       </when>
       <when value="seurat2anndata">
         <param name="input_object_file" type="data" format="rdata" label="Input object in Seurat RDS format"/>
+        <param name="assay" type="text" value="RNA" label="Name of the assay to be transferred" help="Please make sure the assay exists"/>
+        <param name="dtype" type="select" value="RNA" label="Data type of the assay to be transferred" help="Please make sure the data type exists">
+          <option value="data" selected="true">data</option>
+          <option value="counts">counts</option>
+          <option value="scale.data">scale.data</option>
+        </param>
       </when>
     </conditional>
   </inputs>

--- a/tools/tertiary-analysis/sceasy/sceasy_macros.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_macros.xml
@@ -4,12 +4,12 @@
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
 
-0.0.1+galaxy0: Initial version based on sceasy 0.0.2
+0.0.1+galaxy0: Initial version based on sceasy 0.0.3
     ]]></token>
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.0.2">r-sceasy</requirement>
+      <requirement type="package" version="0.0.3">r-sceasy</requirement>
       <yield/>
     </requirements>
   </xml>

--- a/tools/tertiary-analysis/sceasy/sceasy_macros.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_macros.xml
@@ -1,0 +1,24 @@
+<macros>
+  <token name="@TOOL_VERSION@">0.0.1</token>
+  <token name="@HELP@">More information can be found at https://github.com/cellgeni/sceasy</token>
+  <token name="@VERSION_HISTORY@"><![CDATA[
+**Version history**
+
+0.0.1+galaxy0: Initial version based on sceasy 0.0.2
+    ]]></token>
+
+  <xml name="requirements">
+    <requirements>
+      <requirement type="package" version="0.0.2">r-sceasy</requirement>
+      <yield/>
+    </requirements>
+  </xml>
+
+  <xml name="citations">
+    <citations>
+      <yield />
+      <!-- <citation type="doi"> </citation> -->
+      <!-- <citation type="bibtex"> </citation> -->
+    </citations>
+  </xml>
+</macros>

--- a/tools/tertiary-analysis/sceasy/sceasy_macros.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-  <token name="@TOOL_VERSION@">0.0.1</token>
+  <token name="@TOOL_VERSION@">0.0.5</token>
   <token name="@HELP@">More information can be found at https://github.com/cellgeni/sceasy</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**

--- a/tools/tertiary-analysis/sceasy/sceasy_macros.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_macros.xml
@@ -4,7 +4,7 @@
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
 
-0.0.1+galaxy0: Initial version based on sceasy 0.0.5
+0.0.1+galaxy0: Initial version based on sceasy 0.0.5 by Ni Huang, WTSI.
     ]]></token>
 
   <xml name="requirements">

--- a/tools/tertiary-analysis/sceasy/sceasy_macros.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_macros.xml
@@ -4,12 +4,12 @@
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
 
-0.0.1+galaxy0: Initial version based on sceasy 0.0.3
+0.0.1+galaxy0: Initial version based on sceasy 0.0.5
     ]]></token>
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.0.3">r-sceasy</requirement>
+      <requirement type="package" version="0.0.5">r-sceasy</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
This PR adds sceasy, an R package that handles format conversion between loom and sce (and others) that provides the R side of interoperability between dropletutils/scater/sc3 and scanpy.