### PR TITLE
Use base image from our repo for building.

### DIFF
--- a/Dockerfile_init
+++ b/Dockerfile_init
@@ -1,4 +1,4 @@
-FROM quay.io/bgruening/galaxy-init:dev
+FROM quay.io/ebigxa/galaxy-init-base-docker-galaxy-stable:19.05-dev
 
 MAINTAINER EBI Expression Atlas Team <gene-expression@ebi.ac.uk>
 


### PR DESCRIPTION
This is the same base image which I derived like this:

```
docker pull quay.io/bgruening/galaxy-init:dev
docker tag quay.io/bgruening/galaxy-init:dev  quay.io/ebigxa/galaxy-init-base-docker-galaxy-stable:19.05-dev
docker push quay.io/ebigxa/galaxy-init-base-docker-galaxy-stable:19.05-dev
```

This is just to make sure that our building process doesn't get in trouble as `:dev` tag could be reused for something else. I have checked that this is the same image that we have been using for months. 