### PR TITLE
Avoid sanitisation of parameter with variables for regression (Scanpy)

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-regress-variable.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-regress-variable.xml
@@ -21,7 +21,11 @@
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
-    <param name="variable_keys" type="text" label="Variables to regress out" help="Use comma to separate multiple variables. Not supplying variables will simply pass the input data as output unchanged."/>
+    <param name="variable_keys" type="text" label="Variables to regress out" help="Use comma to separate multiple variables. Not supplying variables will simply pass the input data as output unchanged.">
+      <sanitizer>
+        <valid initial="string.printable"/>
+      </sanitizer>
+    </param>
   </inputs>
 
   <outputs>


### PR DESCRIPTION
This makes sure that complex names can be used to refer to metadata column headers can be passed to regress out. Probably we should try to extend this wherever the user is expected to indicated headers. This issue came up when trying to use SC Expression Atlas metadata, which appears in headers like 'Sample Characteristic[individual]'.

(cherry picked from commit 4c24f35f5753abd50ca566a5487604ad075d58f4)