### PR TITLE
Fix to scanpy filter genes script

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -17,7 +17,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-genes
     ${cats}
 #end if
 #if $subsets
-    #set subs = ' '.join(['--subsets {name} {subset}'.format(**$s) for $c in $subsets])
+    #set subs = ' '.join(['--subsets {name} {subset}'.format(**$s) for $s in $subsets])
     ${subs}
 #end if
     @INPUT_OPTS@


### PR DESCRIPTION
@nh3 - Scanpy filter-cells currently broken when supplying subsets- this tiny fix is required.

Can we pass a simple headless gene list under this option as we used to, or does it need to be a headered single-column 'table'? Is it 'index' we need to specify for the gene IDs?