### PR TITLE
Fix hca downloader

### DIFF
--- a/tools/tertiary-analysis/data-hca/matrix-service.xml
+++ b/tools/tertiary-analysis/data-hca/matrix-service.xml
@@ -2,7 +2,7 @@
 <tool id="hca_matrix_downloader" name="Human Cell Atlas Matrix Downloader" version="v0.0.2+galaxy1">
   <description>retrieves expression matrices and metadata from the Human Cell Atlas.</description>
   <requirements>
-    <requirement type="package" version="0.0.2">hca-matrix-downloader</requirement>
+    <requirement type="package" version="0.0.3">hca-matrix-downloader</requirement>
   </requirements>
   <command detect_errors="exit_code"><![CDATA[
 

--- a/tools/tertiary-analysis/data-hca/matrix-service.xml
+++ b/tools/tertiary-analysis/data-hca/matrix-service.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="hca_matrix_downloader" name="Human Cell Atlas Matrix Downloader" version="v0.0.2+galaxy0">
+<tool id="hca_matrix_downloader" name="Human Cell Atlas Matrix Downloader" version="v0.0.2+galaxy1">
   <description>retrieves expression matrices and metadata from the Human Cell Atlas.</description>
   <requirements>
     <requirement type="package" version="0.0.2">hca-matrix-downloader</requirement>
   </requirements>
   <command detect_errors="exit_code"><![CDATA[
 
-hca-matrix-downloader -p '${project}' -f mtx -o out -f '${matrix_format}'
+hca-matrix-downloader -p '${project}' -o out -f '${matrix_format}'
 
 #if $matrix_format == "mtx":
   && hca-mtx-to-10x out.mtx .

--- a/tools/tertiary-analysis/data-hca/matrix-service.xml
+++ b/tools/tertiary-analysis/data-hca/matrix-service.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="hca_matrix_downloader" name="Human Cell Atlas Matrix Downloader" version="v0.0.2+galaxy1">
+<tool id="hca_matrix_downloader" name="Human Cell Atlas Matrix Downloader" version="v0.0.3+galaxy0">
   <description>retrieves expression matrices and metadata from the Human Cell Atlas.</description>
   <requirements>
     <requirement type="package" version="0.0.3">hca-matrix-downloader</requirement>


### PR DESCRIPTION
Currently, hca downloader is broken. I have made a new release of the git repo which should be picked up by bioconda soon at 0.0.3. 

This also fixed an redundant specification of the output format