### PR TITLE
Further minor fix for scanpy-filter-genes

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -17,7 +17,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-genes
     ${cats}
 #end if
 #if $subsets
-    #set subs = ' '.join(['--subsets {name} {subset}'.format(**$s) for $s in $subsets])
+    #set subs = ' '.join(['--subset {name} {subset}'.format(**$s) for $s in $subsets])
     ${subs}
 #end if
     @INPUT_OPTS@


### PR DESCRIPTION
Hi @nh3 - this further fix required for the gene filtering, typo in the CLI call.

Unfortunately even after this fix I still get an error. Example command derived from the Galaxy wrapper (with corrected argument):

```
scanpy-filter-genes --param n_cells 3.0 1000000000.0 --subset gene:index dataset_102795.dat  --input-format 'anndata' input.h5   --show-obj stdout --output-format 'anndata' output.h5
```
Here are the files for testing:

[input.h5.zip](https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/files/3755871/input.h5.zip)
[dataset_102795.dat.zip](https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/files/3755879/dataset_102795.dat.zip)

And the error

```
Traceback (most recent call last):
  File "/path/to/scanpy-scripts/bin/scanpy-filter-genes", line 10, in <module>
    sys.exit(FILTER_CMD())
  File "/path/to/scanpy-scripts/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/path/to/scanpy-scripts/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/path/to/scanpy-scripts/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/path/to/scanpy-scripts/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/path/to/scanpy-scripts/lib/python3.6/site-packages/scanpy_scripts/cmd_utils.py", line 40, in cmd
    func(adata, **kwargs)
  File "/path/to/scanpy-scripts/lib/python3.6/site-packages/scanpy_scripts/lib/_filter.py", line 48, in filter_anndata
    adata, attributes, param, category, subset)
  File "/path/to/scanpy-scripts/lib/python3.6/site-packages/scanpy_scripts/lib/_filter.py", line 192, in _get_filter_conditions
    ct[1] = values
TypeError: 'tuple' object does not support item assignment
```

Is that an error that needs fixing in the CLI?