### PR TITLE
Feature/add scmap preoprocessing

### DIFF
--- a/tools/tertiary-analysis/scmap/scmap_index_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cell.xml
@@ -5,8 +5,7 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
-        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}"
-        scmap-index-cell.R --input-object-file "preprocessed_${input_single_cell_experiment}" --number-chunks '$n_chunks' --number-clusters '$n_clusters' --output-object-file '$output_single_cell_experiment' --random-seed '$random_seed'
+        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}" && scmap-index-cell.R --input-object-file "preprocessed_${input_single_cell_experiment}" --number-chunks '$n_chunks' --number-clusters '$n_clusters' --output-object-file '$output_single_cell_experiment' --random-seed '$random_seed'
     ]]></command>
     <inputs>
         <param type="data" name="input_single_cell_experiment" label="SingleCellExperiment object" format="rdata" help="File with serialized SingleCellExperiment object as produced by 'scmap select features'" />

--- a/tools/tertiary-analysis/scmap/scmap_index_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cell.xml
@@ -5,7 +5,8 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
-        scmap-index-cell.R --input-object-file '$input_single_cell_experiment' --number-chunks '$n_chunks' --number-clusters '$n_clusters' --output-object-file '$output_single_cell_experiment' --random-seed '$random_seed'
+        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}"
+        scmap-index-cell.R --input-object-file "preprocessed_${input_single_cell_experiment}" --number-chunks '$n_chunks' --number-clusters '$n_clusters' --output-object-file '$output_single_cell_experiment' --random-seed '$random_seed'
     ]]></command>
     <inputs>
         <param type="data" name="input_single_cell_experiment" label="SingleCellExperiment object" format="rdata" help="File with serialized SingleCellExperiment object as produced by 'scmap select features'" />

--- a/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
@@ -5,8 +5,7 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
-        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}"
-        scmap-index-cluster.R --input-object-file "preprocessed_${input_single_cell_experiment}" --cluster-col '$cluster_col' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
+        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}" && scmap-index-cluster.R --input-object-file "preprocessed_${input_single_cell_experiment}" --cluster-col '$cluster_col' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
     ]]></command>
     <inputs>
         <param type="data" name="input_single_cell_experiment" label="SingleCellExperiment object" format="rdata" help="File with serialized SingleCellExperiment object as produced by 'scmap select features'" />

--- a/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
@@ -5,7 +5,8 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
-        scmap-index-cluster.R --input-object-file '$input_single_cell_experiment' --cluster-col '$cluster_col' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
+        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}"
+        scmap-index-cluster.R --input-object-file "preprocessed_${input_single_cell_experiment}" --cluster-col '$cluster_col' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
     ]]></command>
     <inputs>
         <param type="data" name="input_single_cell_experiment" label="SingleCellExperiment object" format="rdata" help="File with serialized SingleCellExperiment object as produced by 'scmap select features'" />

--- a/tools/tertiary-analysis/scmap/scmap_macros.xml
+++ b/tools/tertiary-analysis/scmap/scmap_macros.xml
@@ -3,7 +3,9 @@
     <token name="@HELP@">More information can be found at https://bioconductor.org/packages/release/bioc/html/scmap.html</token>
     <xml name="requirements">
       <requirements>
-        <requirement type="package" version="0.0.3">scmap-cli</requirement>
+        <requirement type="package">openblas</requirement>
+        <requirement type="package">bioconductor-delayedarray</requirement>
+        <requirement type="package" version="0.0.4">scmap-cli</requirement>
             <yield/>
       </requirements>
     </xml>

--- a/tools/tertiary-analysis/scmap/scmap_macros.xml
+++ b/tools/tertiary-analysis/scmap/scmap_macros.xml
@@ -3,7 +3,7 @@
     <token name="@HELP@">More information can be found at https://bioconductor.org/packages/release/bioc/html/scmap.html</token>
     <xml name="requirements">
       <requirements>
-        <requirement type="package" version="0.0.2">scmap-cli</requirement>
+        <requirement type="package" version="0.0.3">scmap-cli</requirement>
             <yield/>
       </requirements>
     </xml>

--- a/tools/tertiary-analysis/scmap/scmap_select_features.xml
+++ b/tools/tertiary-analysis/scmap/scmap_select_features.xml
@@ -5,7 +5,8 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
-        scmap-select-features.R --input-object-file '$input_single_cell_experiment' --n-features '$n_features' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
+        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}"
+        scmap-select-features.R --input-object-file "preprocessed_${input_single_cell_experiment}" --n-features '$n_features' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
     ]]></command>
     <inputs>
         <param type="data" name="input_single_cell_experiment" label="SingleCellExperiment object" format="rdata" help="File with serialized SingleCellExperiment object" />

--- a/tools/tertiary-analysis/scmap/scmap_select_features.xml
+++ b/tools/tertiary-analysis/scmap/scmap_select_features.xml
@@ -5,8 +5,7 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
-        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}"
-        scmap-select-features.R --input-object-file "preprocessed_${input_single_cell_experiment}" --n-features '$n_features' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
+        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "${input_single_cell_experiment}.preprocessed" && scmap-select-features.R --input-object-file "${input_single_cell_experiment}.preprocessed" --n-features '$n_features' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
     ]]></command>
     <inputs>
         <param type="data" name="input_single_cell_experiment" label="SingleCellExperiment object" format="rdata" help="File with serialized SingleCellExperiment object" />


### PR DESCRIPTION
This PR adds to the Galaxy wrappers for scmap the preprocessing steps identified as required by @a-solovyev12 , to both the indexing and query (via the feature selection step) stages.

This should address the bug identified by @pcm32.

Note that I've just merged the recipe autobump for scmap-cli that contains the preprocessing, will take a little while to propogate so v0.0.3 is available, so the CI will probably fail now...