### PR TITLE
Attempted fix for lack of MTX exports

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_filter_cells" name="Scanpy FilterCells" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_filter_cells" name="Scanpy FilterCells" version="@TOOL_VERSION@+galaxy1">
   <description>based on counts and numbers of genes expressed</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -25,6 +25,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-cells
 #end if
     @INPUT_OPTS@
     @OUTPUT_OPTS@
+    @EXPORT_MTX_OPTS@
     ]]></command>
 
   <inputs>

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_filter_genes" name="Scanpy FilterGenes" version="@TOOL_VERSION@+galaxy2">
+<tool id="scanpy_filter_genes" name="Scanpy FilterGenes" version="@TOOL_VERSION@+galaxy3">
   <description>based on counts and numbers of cells expressed</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -22,6 +22,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-genes
 #end if
     @INPUT_OPTS@
     @OUTPUT_OPTS@
+    @EXPORT_MTX_OPTS@
 ]]></command>
 
   <inputs>

--- a/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_normalise_data" name="Scanpy NormaliseData" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_normalise_data" name="Scanpy NormaliseData" version="@TOOL_VERSION@+galaxy2">
   <description>to make all cells having the same total expression</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -14,6 +14,7 @@ PYTHONIOENCODING=utf-8 scanpy-normalise-data
     ${log_transform}
     @INPUT_OPTS@
     @OUTPUT_OPTS@
+    @EXPORT_MTX_OPTS@
 ]]></command>
 
   <inputs>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -79,7 +79,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
   </xml>
 
   <xml name="export_mtx_params">
-    <param name="export_mtx" argument="--export-mtx" type="boolean" truevalue="--export-mtx ./" falsevalue="" checked="false" label="Save normalised data to 10x mtx format" help="If enabled, it will generate in addition to the main output in Loom or AnnData an export in 10x format of the normalised data."/>
+    <param name="export_mtx" argument="--export-mtx" type="boolean" truevalue="--export-mtx ./" falsevalue="" checked="false" label="Save to 10x mtx format" help="If enabled, it will generate in addition to the main output in Loom or AnnData an export in 10x format."/>
   </xml>
 
   <xml name="export_mtx_outputs">


### PR DESCRIPTION
MTX export seems to be broken in current Scanpy Galaxy wrappers. This is what I /think/ the fix is, though @nh3 may know better. It worked in the cell filtering tool when I tested under Planemo.

Also, the name of the export field was normalisation-specific, while the functionality has been factored out so the message should be generic- I've edited the help text accordingly.