### PR TITLE
Feature/dropletutils empty drops

### DIFF
--- a/config/tool_conf.xml
+++ b/config/tool_conf.xml
@@ -161,6 +161,7 @@
   </section>
   <section name="DropletUtils" id="droputil-tools">
     <tool file="tertiary-analysis/dropletutils/dropletutils-read-10x.xml"/>
+    <tool file="tertiary-analysis/dropletutils/dropletutils-empty-drops.xml"/>
   </section>
   <section name="Scater" id="scater-tools">
     <tool file="tertiary-analysis/scater/scater-calculate-cpm.xml"/>

--- a/tools/tertiary-analysis/dropletutils/dropletutils-empty-drops.xml
+++ b/tools/tertiary-analysis/dropletutils/dropletutils-empty-drops.xml
@@ -32,11 +32,9 @@
   </outputs>
 
   <help><![CDATA[
-=============================================================
-Distinguish between droplets containing cells and ambient RNA
-in a droplet-based single-cell RNA sequencing experiment. 
-(`emptyDrops()`)
-=============================================================
+========================================================================================================================================
+Distinguish between droplets containing cells and ambient RNA in a droplet-based single-cell RNA sequencing experiment. (`emptyDrops()`)
+========================================================================================================================================
 
 This tool takes a SingleCellExeriment object and esitmates empty cells. From ?emptyDrops():
 

--- a/tools/tertiary-analysis/dropletutils/dropletutils-empty-drops.xml
+++ b/tools/tertiary-analysis/dropletutils/dropletutils-empty-drops.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tool id="dropletutils_empty-drops" name="DropletUtils emptyDrops" version="@TOOL_VERSION@+galaxy0">
+  <description>Distinguish between droplets containing cells and ambient RNA in a droplet-based single-cell RNA sequencing experiment.</description>
+  <macros>
+    <import>dropletutils_macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <command detect_errors="exit_code"><![CDATA[
+      dropletutils-empty-drops.R --input-object-file "${input}" --output-object-file "${output_rds}" --output-text-file "${output_txt}" --lower "${lower}" --niters "${niters}" --filter-fdr "${filter_fdr}" --test-ambient "${testambient}" --filter-empty "${filter_empty}"      
+#if $ignore != ''
+--ignore $ignore 
+#end if
+#if $retain != ''
+--retain $retain
+#end if
+]]></command>
+
+  <inputs>
+    <param name="input" argument="--input-object-file" type="data" format="rdata" label="SingleCellExperiment RDS object" help="e.g. Output from DropletUtils Read10x." />
+    <param name="lower" argument="--lower" type="integer" optional="True" label="UMI count lower bound" value='100' help="A numeric scalar specifying the lower bound on the total UMI count, at or below which all barcodes are assumed to correspond to empty droplets." />
+    <param name="niters" argument="--niters" type="integer" optional="True" value='1000' label="Number of iterations" help="An integer scalar specifying the number of iterations to use for the Monte Carlo p-value calculations." />
+    <param name="filter_fdr" argument="--filter-fdr" type="float" value='0.01' label="FDR filter for removal of barcodes with no cells" />
+    <param name="testambient" argument="--test-ambient" type="boolean" checked="false" label="Should results be returned for barcodes with totals less than or equal to the value of 'lower'?"/>
+    <param name="ignore" argument="--ignore" type="integer" optional="True" value='' label="Ignore barcodes threshold" help="A numeric scalar specifying the lower bound on the total UMI count, at or below which barcodes will be ignored. (default: none)" />
+    <param name="retain" argument="--retain" type="integer" optional="True" label="Retain barcodes threshold" help="A numeric scalar specifying the threshold for the total UMI count above which all barcodes are assumed to contain cells. (default: none)" />
+    <param name="filter_empty" argument="--filter-empty" type="boolean" checked="false" label="Should barcodes estimated to have no cells be removed from the output object?"/>
+  </inputs>
+
+  <outputs>
+    <data name="output_rds" format="rdata" label="${tool.name} on ${on_string}: serialized SingleCellExperiment object"/>
+    <data name="output_txt" format="txt" label="${tool.name} on ${on_string}: tabular output"/>
+  </outputs>
+
+  <help><![CDATA[
+=============================================================
+Distinguish between droplets containing cells and ambient RNA
+in a droplet-based single-cell RNA sequencing experiment. 
+(`emptyDrops()`)
+=============================================================
+
+This tool takes a SingleCellExeriment object and esitmates empty cells. From ?emptyDrops():
+
+The emptyDrops function combines the results of testEmptyDrops with barcodeRanks to identify droplets that are likely to contain cells. Barcodes that contain more than retain total counts are always retained. This ensures that large cells with profiles that are very similar to the ambient pool are not inadvertently discarded. If retain is not specified, it is set to the total count at the knee point detected by barcodeRanks. Manual specification of retain may be useful if the knee point was not correctly identified in complex log-rank curves. Users can also set retain=Inf to disable automatic retention of barcodes with large totals.
+
+The Benjamini-Hochberg correction is also applied to the Monte Carlo p-values to correct for multiple testing. Cells can then be defined by taking all barcodes with significantly non-ambient profiles, e.g., at a false discovery rate of 0.1%. All barcodes with total counts above K (or retain) are assigned p-values of zero during correction, reflecting our assumption that they are true positives. This ensures that their Monte Carlo p-values do not affect the correction of other genes, and also means that they will have FDR values of zero. Nonetheless, their original Monte Carlo p-values are still reported in the output.
+
+@HELP@
+]]></help>
+  <expand macro="citations"/>
+</tool>

--- a/tools/tertiary-analysis/dropletutils/dropletutils_macros.xml
+++ b/tools/tertiary-analysis/dropletutils/dropletutils_macros.xml
@@ -5,7 +5,8 @@
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.0.1">dropletutils-scripts</requirement>
+      <requirement type="package">openblas</requirement>
+      <requirement type="package" version="0.0.4">dropletutils-scripts</requirement>
     </requirements>
   </xml>
 


### PR DESCRIPTION
This PR adds the Galaxy layer for the emptyDrops() function of DropletUtils, which we use in our production workflows (and which I'd like to use for the teaching).

It bumps the underlying package to get a workaround for a bug I report earlier this year associated non-integer expression values: https://support.bioconductor.org/p/123738/. It also adds 'openblas' as a dependency (something I'm finding I need to do a lot lately).

Tool works in Planemo, and passes lint (except for tests, which I need to come back to for DropletUtils). 