### PR TITLE
Avoid issues with Atlas fields with brackets

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -23,7 +23,11 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot embed
   <inputs>
     <expand macro="input_object_params"/>
     <param name="basis" argument="--basis" type="text" label="Name of the embedding to plot"/>
-    <param name="color_by" argument="--color" type="text" label="Color by attributes, comma separated texts"/>
+    <param name="color_by" argument="--color" type="text" label="Color by attributes, comma separated texts">
+      <sanitizer>
+        <valid initial="string.printable"/>
+      </sanitizer>
+    </param>
     <param name="use_raw" argument="--use-raw" type="boolean" checked="true" truevalue="--use-raw" falsevalue="--no-raw" label="Use raw attributes if present"/>
     <param name="legend_loc" argument="--legend-loc" type="select" label="Location of legend">
       <option value="right margin" selected="true">Right margin</option>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_plot_embed" name="Scanpy PlotEmbed" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_plot_embed" name="Scanpy PlotEmbed" version="@TOOL_VERSION@+galaxy1">
   <description>visualise cell embeddings</description>
   <macros>
     <import>scanpy_macros2.xml</import>


### PR DESCRIPTION
Atlas fields have brackets, which when given to fields like the colors here it breaks usage as Galaxy transform brackets and other characters.