### PR TITLE
Check for incorrect dimensions when transforming matrix

### DIFF
--- a/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.py
+++ b/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.py
@@ -49,7 +49,20 @@ if not os.path.exists(gene_file):
 cb_names = [cell_prefix + s for s in pd.read_csv(cb_file, header=None)[0].values]
 gene_names = pd.read_csv(gene_file, header=None)[0].values
 umi_counts = mmread( quant_file )
-    
+   
+nrows = umi_counts.shape[0]  
+ncols = umi_counts.shape[1]  
+
+# Add a dimension check
+
+if len(cb_names) != nrows:
+    print('The number of matrix rows (%d) does not match the number of supplied bardcodes (%d)' % (nrows, len(cb_names)))
+    sys.exit(1)
+
+if len(gene_names) != nrows:
+    print('The number of matrix columns (%d) does not match the number of supplied genes (%d)' % (ncols, len(gene_names)))
+    sys.exit(1)
+
 # Write outputs to a .mtx file readable by tools expecting 10X outputs.
 # Barcodes file works as-is, genes need to be two-column, duplicating the
 # identifiers. Matrix itself needs to have genes by row, so we transpose. 

--- a/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.py
+++ b/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.py
@@ -56,7 +56,7 @@ ncols = umi_counts.shape[1]
 # Add a dimension check
 
 if len(cb_names) != nrows:
-    print('The number of matrix rows (%d) does not match the number of supplied bardcodes (%d)' % (nrows, len(cb_names)))
+    print('The number of matrix rows (%d) does not match the number of supplied barcodes (%d)' % (nrows, len(cb_names)))
     sys.exit(1)
 
 if len(gene_names) != nrows:

--- a/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
+++ b/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
@@ -1,4 +1,4 @@
-<tool id="_salmon_kallisto_mtx_to_10x" name="salmonKallistoMtxTo10x" version="0.0.1+galaxy2">
+<tool id="_salmon_kallisto_mtx_to_10x" name="salmonKallistoMtxTo10x" version="0.0.1+galaxy3">
     <description>Transforms .mtx matrix and associated labels into a format compatible with tools expecting old-style 10X data</description>
     <requirements>
       <requirement type="package">scipy</requirement>


### PR DESCRIPTION
Just a tweak to deal with over-creative users, producing an error if the numbers of gene and barcode labels don't match matrix dimensions. 