### PR TITLE
Wider scanpy compatibility and upgrade to 0.2.8

### DIFF
--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="anndata_ops" name="AnnData Operations" version="0.0.1+galaxy0">
+<tool id="anndata_ops" name="AnnData Operations" version="0.0.1+galaxy1">
   <description>modifies metadata and flags genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -53,7 +53,8 @@ adata.write('output.h5', compression='gzip')
 </configfiles>
 
   <inputs>
-    <param name="input_obj_file" argument="input-object-file" type="data" format="h5" label="Input object in hdf5 AnnData format"/>
+    <param name="input_obj_file" argument="input-object-file" type="data" format="h5,h5ad" label="Input object in hdf5 AnnData format"/>
+    <expand macro="output_object_params_no_loom"/>
     <repeat name="modifications" title="Change field names in AnnData observations" min="0">
       <param name="from_obs" type="text" label="Original name" help="Name in observations that you want to change">
         <sanitizer>
@@ -71,7 +72,7 @@ adata.write('output.h5', compression='gzip')
   </inputs>
 
   <outputs>
-    <data name="output" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: anndata with metadata changes."/>
+    <expand macro="output_data_obj_no_loom" description="metadata changes on"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -80,7 +80,7 @@ adata.write('output.h5', compression='gzip')
       <param name="input_obj_file" value="find_cluster.h5"/>
       <param name="input_format" value="anndata"/>
       <param name="color_by" value="louvain"/>
-      <output name="output" file="output.h5" ftype="h5" compare="sim_size"/>
+      <output name="output_h5ad" file="output.h5" ftype="h5" compare="sim_size"/>
     </test>
   </tests>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_filter_cells" name="Scanpy FilterCells" version="@TOOL_VERSION@+galaxy3">
+<tool id="scanpy_filter_cells" name="Scanpy FilterCells" version="@TOOL_VERSION@+galaxy6">
   <description>based on counts and numbers of genes expressed</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -59,7 +59,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-cells
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Filtered cells"/>
+    <expand macro="output_data_obj" description="Filtered cells"/>
     <expand macro="export_mtx_outputs"/>
   </outputs>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_filter_genes" name="Scanpy FilterGenes" version="@TOOL_VERSION@+galaxy5">
+<tool id="scanpy_filter_genes" name="Scanpy FilterGenes" version="@TOOL_VERSION@+galaxy6">
   <description>based on counts and numbers of cells expressed</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -52,7 +52,7 @@ PYTHONIOENCODING=utf-8 scanpy-filter-genes
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Filtered genes"/>
+    <expand macro="output_data_obj" description="Filtered cells"/>
     <expand macro="export_mtx_outputs"/>
   </outputs>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_cluster" name="Scanpy FindCluster" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_find_cluster" name="Scanpy FindCluster" version="@TOOL_VERSION@+galaxy6">
   <description>based on community detection on KNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -69,7 +69,7 @@ PYTHONIOENCODING=utf-8 scanpy-find-cluster
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Cluster object"/>
+    <expand macro="output_data_obj" description="Clusters"/>
     <data name="output_txt" format="tsv" from_work_dir="output.tsv" label="${tool.name} on ${on_string}: Cluster table">
       <filter>output_cluster</filter>
     </data>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_markers" name="Scanpy FindMarkers" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_find_markers" name="Scanpy FindMarkers" version="@TOOL_VERSION@+galaxy6">
   <description>to find differentially expressed genes between groups</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -60,7 +60,7 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Marker object"/>
+    <expand macro="output_data_obj" description="Marker genes"/>
     <data name="output_csv" format="csv" from_work_dir="output.csv" label="${tool.name} on ${on_string}: Marker table">
       <filter>output_markers</filter>
     </data>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_variable_genes" name="Scanpy FindVariableGenes" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_find_variable_genes" name="Scanpy FindVariableGenes" version="@TOOL_VERSION@+galaxy6">
   <description>based on normalised dispersion of expression</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -50,7 +50,7 @@ PYTHONIOENCODING=utf-8 scanpy-find-variable-genes
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Variable genes"/>
+    <expand macro="output_data_obj" description="Variable genes"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -49,7 +49,7 @@ PYTHONIOENCODING=utf-8 scanpy-neighbors
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Graph object"/>
+    <expand macro="output_data_obj" description="Graph object"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
@@ -33,7 +33,7 @@ PYTHONIOENCODING=utf-8 scanpy-normalise-data
   </inputs>
 
   <outputs>
-    <expand macro="output_data_obj"/>
+    <expand macro="output_data_obj" description="Normalised data"/>
     <expand macro="export_mtx_outputs"/>
   </outputs>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_normalise_data" name="Scanpy NormaliseData" version="@TOOL_VERSION@+galaxy3">
+<tool id="scanpy_normalise_data" name="Scanpy NormaliseData" version="@TOOL_VERSION@+galaxy6">
   <description>to make all cells having the same total expression</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -25,7 +25,7 @@ PYTHONIOENCODING=utf-8 scanpy-normalise-data
     <param name="fraction" argument="--fraction" type="float" value="1" min="0" max="1"
            label="Exclude top expressed genes until the remaining account for no greater than specified fraction of total counts"
            help="Only non-excluded genes will sum up the target number."/>
-    <param name="log_transform" argument="--no-log-transform" type="boolean" truevalue="" falsevalue="--no-log-transform" checked="True" 
+    <param name="log_transform" argument="--no-log-transform" type="boolean" truevalue="" falsevalue="--no-log-transform" checked="True"
            label="Apply log transform?" help="If enabled, will apply a log transformation following normalisation."/>
     <param name="save_raw" argument="--save-raw" type="boolean" truevalue="yes" falsevalue="no" checked="true"
            label="Save normalised data in `.raw`" help="The saved normalised data are log1p transformed."/>
@@ -33,7 +33,7 @@ PYTHONIOENCODING=utf-8 scanpy-normalise-data
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Normalised data"/>
+    <expand macro="output_data_obj"/>
     <expand macro="export_mtx_outputs"/>
   </outputs>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -17,6 +17,9 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot embed
 #if $point_size
     --size ${point_size}
 #end if
+#if $gene_symbols_field
+    --gene-symbols ${gene_symbols_field}
+#end if
     @PLOT_OPTS@
 ]]></command>
 
@@ -28,6 +31,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot embed
         <valid initial="string.printable"/>
       </sanitizer>
     </param>
+    <param name="gene_symbols_field" argument="--gene-symbols" type="text" optional="true" label="Field for gene symbols" help="The field used in the AnnData object to store gene symbols, leave blank for the default (index), else a common value is 'gene_symbols'"/>
     <param name="use_raw" argument="--use-raw" type="boolean" checked="true" truevalue="--use-raw" falsevalue="--no-raw" label="Use raw attributes if present"/>
     <param name="legend_loc" argument="--legend-loc" type="select" label="Location of legend">
       <option value="right margin" selected="true">Right margin</option>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_plot_embed" name="Scanpy PlotEmbed" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_plot_embed" name="Scanpy PlotEmbed" version="@TOOL_VERSION@+galaxy6">
   <description>visualise cell embeddings</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -40,7 +40,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot embed
   </inputs>
 
   <outputs>
-    <data name="output_png" format="png" from_work_dir="output.png" label="${tool.name} on ${on_string}: embedding plot"/>
+    <data name="output_png" format="png" from_work_dir="output.png" label="${tool.name} on ${on_string}: ${basis} embedding plot"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_plot_trajectory" name="Scanpy PlotTrajectory" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_plot_trajectory" name="Scanpy PlotTrajectory" version="@TOOL_VERSION@+galaxy6">
   <description>visualise cell trajectories</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_read_10x" name="Scanpy Read10x" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_read_10x" name="Scanpy Read10x" version="@TOOL_VERSION@+galaxy6">
   <description>into hdf5 object handled by scanpy</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -30,14 +30,14 @@ PYTHONIOENCODING=utf-8 scanpy-read-10x
     <param name="gene_meta" type="data" format="tsv,tabular" label="Gene metadata table" optional="true"
            help="Requires a header row and index column that matches the gene table"/>
     <expand macro="output_object_params"/>
-    <param name="var_names" type="select" label="Attribute used as annotation index">
+    <param name="var_names" type="select" label="Attribute used as annotation index" help="If Gene ID is selected the index will point to the gene identifiers (first columns expected) and the gene symbols will be left in a field called 'gene_symbols'.">
       <option value="gene_ids" selected="true">Gene ID</option>
       <option value="gene_symbols">Gene symbol</option>
     </param>
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: ${output_format}"/>
+    <expand macro="output_data_obj" description="${output_format}"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-regress-variable.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-regress-variable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_regress_variable" name="Scanpy RegressOut" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_regress_variable" name="Scanpy RegressOut" version="@TOOL_VERSION@+galaxy6">
   <description>variables that might introduce batch effect</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -29,7 +29,7 @@
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Scaled data"/>
+    <expand macro="output_data_obj" description="Regressed out ${variable_keys}"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
@@ -36,7 +36,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli embed diffmap
   </inputs>
 
   <outputs>
-    <expand macro="output_data_obj" description="Diffussio Map"/>
+    <expand macro="output_data_obj" description="Diffussion Map"/>
     <data name="output_embed" format="tsv" from_work_dir="embed.tsv" label="${tool.name} on ${on_string}: diffmap embedding">
       <filter>export_embed</filter>
     </data>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_diffmap" name="Scanpy DiffusionMap" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_run_diffmap" name="Scanpy DiffusionMap" version="@TOOL_VERSION@+galaxy6">
   <description>calculate diffusion components</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -36,7 +36,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli embed diffmap
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: diffmap object"/>
+    <expand macro="output_data_obj" description="Diffussio Map"/>
     <data name="output_embed" format="tsv" from_work_dir="embed.tsv" label="${tool.name} on ${on_string}: diffmap embedding">
       <filter>export_embed</filter>
     </data>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_dpt" name="Scanpy DPT" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_run_dpt" name="Scanpy DPT" version="@TOOL_VERSION@+galaxy6">
   <description>diffusion pseudotime inference</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -46,7 +46,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli dpt
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: dpt object"/>
+    <expand macro="output_data_obj" description="Diffussion pseudotime inference"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-fdg.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-fdg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_fdg" name="Scanpy RunFDG" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_run_fdg" name="Scanpy RunFDG" version="@TOOL_VERSION@+galaxy6">
   <description>visualise cell clusters using force-directed graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -52,7 +52,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli embed fdg
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: FDG object"/>
+    <expand macro="output_data_obj" description="FDG object"/>
     <data name="output_embed" format="csv" from_work_dir="embeddings.csv" label="${tool.name} on ${on_string}: FDG embeddings">
       <filter>embeddings</filter>
     </data>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_paga" name="Scanpy PAGA" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_run_paga" name="Scanpy PAGA" version="@TOOL_VERSION@+galaxy6">
   <description>trajectory inference</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -29,7 +29,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli paga
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: PAGA object"/>
+    <expand macro="output_data_obj" description="PAGA object"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_pca" name="Scanpy RunPCA" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_run_pca" name="Scanpy RunPCA" version="@TOOL_VERSION@+galaxy6">
   <description>for dimensionality reduction</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -55,7 +55,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-pca
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: PCA object"/>
+    <expand macro="output_data_obj" description="PCA object"/>
     <data name="output_embed" format="tsv" from_work_dir="embeddings.tsv" label="${tool.name} on ${on_string}: PCA embeddings">
       <filter>extra_outputs and 'embeddings' in extra_outputs.split(',')</filter>
     </data>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy6">
   <description>visualise cell clusters using tSNE</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -64,7 +64,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
         <param name="perplexity_file" argument="--perplexity" type="data" format="txt,tsv" label="The perplexity is related to the number of nearest neighbours" help="For use with the parameter iterator. Overrides the persplexity option above" optional="true"/>
         <param name="early_exaggeration" argument="--early-exaggeration" type="float" value="12" label="Controls the tightness within and between clusters"/>
         <param name="learning_rate" argument="--learning-rate" type="float" value="1000" label="Learning rate, should be between 100 and 1000"/>
-        <param name="fast_tsne" type="boolean" checked="true" label="Use multicoreTSNE"/>
+        <param name="fast_tsne" type="boolean" checked="false" label="Use multicoreTSNE" help="Depending on the setup and version, the availability of the needed library might vary and hence fail."/>
         <param name="n_job" argument="--n-jobs" type="integer" optional="true" label="The number of jobs"/>
         <param name="n_pc" argument="--n-pcs" type="integer" optional="true" label="The number of PCs to use"/>
         <param name="random_seed" argument="--random-seed" type="integer" value="0" label="Seed for random number generator"/>
@@ -74,7 +74,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: tSNE object"/>
+    <expand macro="output_data_obj" description="tSNE object"/>
     <data name="output_embed" format="csv" from_work_dir="embeddings.csv" label="${tool.name} on ${on_string}: tSNE embeddings">
       <filter>embeddings</filter>
     </data>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_umap" name="Scanpy RunUMAP" version="@TOOL_VERSION@+galaxy1">
+<tool id="scanpy_run_umap" name="Scanpy RunUMAP" version="@TOOL_VERSION@+galaxy6">
   <description>visualise cell clusters using UMAP</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -64,7 +64,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-umap
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: UMAP object"/>
+    <expand macro="output_data_obj" description="UMAP object"/>
     <data name="output_embed" format="csv" from_work_dir="embeddings.csv" label="${tool.name} on ${on_string}: UMAP embeddings">
       <filter>embeddings</filter>
     </data>

--- a/tools/tertiary-analysis/scanpy/scanpy-scale-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-scale-data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_scale_data" name="Scanpy ScaleData" version="@TOOL_VERSION@+galaxy0">
+<tool id="scanpy_scale_data" name="Scanpy ScaleData" version="@TOOL_VERSION@+galaxy6">
   <description>to make expression variance the same for all genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -25,7 +25,7 @@ PYTHONIOENCODING=utf-8 scanpy-scale-data
   </inputs>
 
   <outputs>
-    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: Scaled data"/>
+    <expand macro="output_data_obj" description="Scaled data"/>
   </outputs>
 
   <tests>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -3,6 +3,7 @@
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
+1.4.3+galaxy6: Update to scanpy-scripts 0.2.8 (running scanpy ==1.4.3) and wider compatibility with other Galaxy modules. Bug fixes in filtering and plotting improvements.
 
 1.4.3+galaxy0: Update to scanpy-scripts 0.2.5 (running scanpy ==1.4.3).
 
@@ -17,7 +18,11 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
     --input-format '${input_format}' input.h5
   </token>
   <token name="@OUTPUT_OPTS@">
-    --show-obj stdout --output-format '${output_format}' output.h5
+#if 'anndata' in $output_format
+    --show-obj stdout --output-format anndata output.h5
+#else
+    --show-obj stdout --output-format loom output.h5
+#end if
   </token>
   <token name="@PLOT_OPTS@">
 #if $fig_title
@@ -55,7 +60,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
   </xml>
 
   <xml name="input_object_params">
-    <param name="input_obj_file" argument="input-object-file" type="data" format="h5" label="Input object in hdf5 format"/>
+    <param name="input_obj_file" argument="input-object-file" type="data" format="h5,h5ad" label="Input object in AnnData/Loom format"/>
     <param name="input_format" argument="--input-format" type="select" label="Format of input object">
       <option value="anndata" selected="true">AnnData format hdf5</option>
       <option value="loom">Loom format hdf5</option>
@@ -64,9 +69,27 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="output_object_params">
     <param name="output_format" argument="--output-format" type="select" label="Format of output object">
-      <option value="anndata" selected="true">AnnData format hdf5</option>
-      <option value="loom">Loom format hdf5</option>
+      <option value="anndata_h5ad" selected="true">AnnData format</option>
+      <option value="anndata">AnnData format (h5 for older versions)</option>
+      <option value="loom">Loom format</option>
+      <option value="loom_legacy">Loom format (h5 for older versions)</option>
     </param>
+  </xml>
+
+<!--   -->
+  <xml name="output_data_obj" token_description="operation">
+    <data name="output_h5ad" format="h5ad" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData">
+      <filter>output_format == 'anndata_h5ad'</filter>
+    </data>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData">
+      <filter>output_format == 'anndata'</filter>
+    </data>
+    <data name="output_loom_legacy" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ Loom">
+      <filter>output_format == 'loom'</filter>
+    </data>
+    <data name="output_loom" format="loom" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ Loom">
+      <filter>output_format == 'loom_legacy'</filter>
+    </data>
   </xml>
 
   <xml name="output_plot_params">

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -3,6 +3,7 @@
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
+
 1.4.3+galaxy6: Update to scanpy-scripts 0.2.8 (running scanpy ==1.4.3) and wider compatibility with other Galaxy modules. Bug fixes in filtering and plotting improvements.
 
 1.4.3+galaxy0: Update to scanpy-scripts 0.2.5 (running scanpy ==1.4.3).
@@ -18,7 +19,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
     --input-format '${input_format}' input.h5
   </token>
   <token name="@OUTPUT_OPTS@">
-#if 'anndata' in $output_format
+#if str($output_format).startswith('anndata')
     --show-obj stdout --output-format anndata output.h5
 #else
     --show-obj stdout --output-format loom output.h5
@@ -38,7 +39,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.2.6">scanpy-scripts</requirement>
+      <requirement type="package" version="0.2.8">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>
@@ -76,7 +77,22 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
     </param>
   </xml>
 
-<!--   -->
+  <xml name="output_object_params_no_loom">
+    <param name="output_format" argument="--output-format" type="select" label="Format of output object">
+      <option value="anndata_h5ad" selected="true">AnnData format</option>
+      <option value="anndata">AnnData format (h5 for older versions)</option>
+    </param>
+  </xml>
+
+  <xml name="output_data_obj_no_loom" token_description="operation">
+    <data name="output_h5ad" format="h5ad" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData">
+      <filter>output_format == 'anndata_h5ad'</filter>
+    </data>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData">
+      <filter>output_format == 'anndata'</filter>
+    </data>
+  </xml>
+
   <xml name="output_data_obj" token_description="operation">
     <data name="output_h5ad" format="h5ad" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData">
       <filter>output_format == 'anndata_h5ad'</filter>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -101,10 +101,10 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
       <filter>output_format == 'anndata'</filter>
     </data>
     <data name="output_loom_legacy" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ Loom">
-      <filter>output_format == 'loom'</filter>
+      <filter>output_format == 'loom_legacy'</filter>
     </data>
     <data name="output_loom" format="loom" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ Loom">
-      <filter>output_format == 'loom_legacy'</filter>
+      <filter>output_format == 'loom'</filter>
     </data>
   </xml>
 


### PR DESCRIPTION
This PR:

- Moves the scanpy and anndata scripts to scanpy-scripts 0.2.8 (all tested on planemo).
- Improves the supported input/output formats, so that our modules accept and write from/to `h5ad`, `h5` and `loom` Galaxy datatypes. This enables direct interaction with other AnnData and Scanpy tools available for Galaxy.
- Supports gene symbols on plot embeddings. 

Everything tested on planemo with the course workflows.