### PR TITLE
Move to SCCAF 0.0.9

### DIFF
--- a/tools/tertiary-analysis/sccaf/sccaf_macros.xml
+++ b/tools/tertiary-analysis/sccaf/sccaf_macros.xml
@@ -4,7 +4,7 @@
       <requirement type="package" version="@TOOL_VERSION@">sccaf</requirement>
     </requirements>
   </xml>
-  <token name="@TOOL_VERSION@">0.0.8</token>
+  <token name="@TOOL_VERSION@">0.0.9</token>
   <token name="@SCCAF_INTRO@">
 SCCAF explained
 ===============
@@ -67,17 +67,21 @@ characterised by the feature genes as markers.
     </citations>
   </xml>
   <xml name="input_object_params">
-    <param name="input_obj_file" argument="--input-object-file" type="data" format="h5" label="Input object in AnnData hdf5 format" help="Normally the result of Scanpy (or equivalent), which already has both a visualisation (either tSNE, UMAP or PCA - needed) and clustering (ideally) pre-computed."/>
-    <param name="input_format" argument="--input-format" type="select" label="Format of input object">
-      <option value="anndata" selected="true">AnnData format hdf5</option>
-      <option value="loom">Loom format hdf5, current support is incomplete</option>
-    </param>
+    <param name="input_obj_file" argument="--input-object-file" type="data" format="h5,h5ad" label="Input object in AnnData hdf5 format" help="Normally the result of Scanpy (or equivalent), which already has both a visualisation (either tSNE, UMAP or PCA - needed) and clustering (ideally) pre-computed."/>
   </xml>
   <xml name="output_object_params">
     <param name="output_format" argument="--output-format" type="select" label="Format of output object">
-      <option value="anndata" selected="true">AnnData format hdf5</option>
-      <option value="loom">Loom format hdf5, current support is defective</option>
+      <option value="anndata_h5ad" selected="true">AnnData format hdf5</option>
+      <option value="anndata">AnnData format (h5 for older versions)</option>
     </param>
+  </xml>
+  <xml name="output_data_obj" token_description="operation">
+    <data name="output_h5ad" format="h5ad" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData">
+      <filter>output_format == 'anndata_h5ad'</filter>
+    </data>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData">
+      <filter>output_format == 'anndata'</filter>
+    </data>
   </xml>
   <xml name="output_plot_params">
     <param name="color_by" argument="--color-by" type="text" value="n_genes" label="Color by attributes, comma separated strings"/>

--- a/tools/tertiary-analysis/sccaf/sccaf_regress_out.xml
+++ b/tools/tertiary-analysis/sccaf/sccaf_regress_out.xml
@@ -23,7 +23,7 @@
       <param name="input_obj_file" value="find_cluster.h5"/>
       <param name="input_format" value="anndata"/>
       <param name="color_by" value="louvain"/>
-      <output name="output" file="output.h5" ftype="h5" compare="sim_size"/>
+      <output name="output_h5ad" file="output.h5" ftype="h5" compare="sim_size"/>
     </test>
   </tests>
 

--- a/tools/tertiary-analysis/sccaf/sccaf_regress_out.xml
+++ b/tools/tertiary-analysis/sccaf/sccaf_regress_out.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="sccaf_regress_out" name="SCCAF mulitple regress out" version="@TOOL_VERSION@+galaxy0">
+<tool id="sccaf_regress_out" name="SCCAF mulitple regress out" version="@TOOL_VERSION@+galaxy1">
   <description>with multiple categorical keys on an AnnData object.</description>
   <macros>
     <import>sccaf_macros.xml</import>
@@ -11,10 +11,11 @@
   ]]></command>
   <inputs>
     <param name="input_obj_file" argument="input-object-file" type="data" format="h5" label="Input object in hdf5 AnnData format"/>
+    <expand macro="output_object_params"/>
     <param name="keys_to_regress" label="Keys to regress" help="Comma separated keys for regressing out; they need to exist in the observations part of the AnnData object." type="text"/>
   </inputs>
   <outputs>
-    <data name="output" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: regressesed out on ${keys_to_regress}"/>
+    <expand macro="output_data_obj" description="regressed out on ${keys_to_regress}"/>
   </outputs>
 
   <tests>


### PR DESCRIPTION
This PR:

- Moves to the latest SCCAF version to avoid issues with badly coded warning messages.
- Adds h5ad Galaxy datatype compatibility.