### PR TITLE
Feature/add file dep

### DIFF
--- a/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
+++ b/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
@@ -1,4 +1,4 @@
-<tool id="_salmon_kallisto_mtx_to_10x" name="salmonKallistoMtxTo10x" version="0.0.1+galaxy4" profile="18.01">
+<tool id="_salmon_kallisto_mtx_to_10x" name="salmonKallistoMtxTo10x" version="0.0.1+galaxy5" profile="18.01">
     <description>Transforms .mtx matrix and associated labels into a format compatible with tools expecting old-style 10X data</description>
     <requirements>
       <requirement type="package" version="1.4.1">scipy</requirement>

--- a/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
+++ b/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
@@ -3,6 +3,7 @@
     <requirements>
       <requirement type="package" version="1.4.1">scipy</requirement>
       <requirement type="package" version="1.0.1">pandas</requirement>
+      <requirement type="package" version="5.37">file</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         file $mtx_file | grep 'gzip compressed' > /dev/null;


### PR DESCRIPTION
This PR adds the 'file' utility as an explicit dependency for this tool, used for sniffing whether the input is compressed or not. It was present as standard when we were deploying on LSF but not in the cloud-based deployments we're using right now.

I'm guessing we'll have to make a container with the additional dependency too.