### PR TITLE
PNG needs cairo

### DIFF
--- a/tools/droplet-barcode-plot/dropletBarcodePlot.xml
+++ b/tools/droplet-barcode-plot/dropletBarcodePlot.xml
@@ -1,4 +1,4 @@
-<tool id="_dropletBarcodePlot" name="Droplet barcode rank plot" version="1.6.1+galaxy1" profile="18.01">
+<tool id="_dropletBarcodePlot" name="Droplet barcode rank plot" version="1.6.1+galaxy2" profile="18.01">
     <description>Creates a barcode rank plot for quality control of droplet single-cell RNA-seq data</description>
     <requirements>
       <requirement type="package" version="1.6.1">bioconductor-dropletutils</requirement>
@@ -8,6 +8,7 @@
       <requirement type="package" version="1.6.4">r-optparse</requirement>
       <requirement type="package" version="2.3">r-gridextra</requirement>
       <requirement type="package" version="0.12.0">bioconductor-delayedarray</requirement>
+      <requirement type="package" version="1.14.12">cairo</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         $__tool_directory__/dropletBarcodePlot.R --output-plot "${plot_file}" --output-thresholds "${thresholds_file}" --label "${label}" --density-bins "${density_bins}" --roryk-multiplier "${roryk_multiplier}"


### PR DESCRIPTION
I'm getting the following error trying to use plotting scripts in the our training Galaxy instance newly deployed to GCP:

```
Warning messages:
1: In png(width = 1000, height = 600, file = opt$output_plot) :
  unable to load shared object '/usr/local/lib/R/library/grDevices/libs//cairo.so':
  libXrender.so.1: cannot open shared object file: No such file or directory
2: In png(width = 1000, height = 600, file = opt$output_plot) :
  failed to load cairo DLL
```

So we need to add Cairo as explicit dependency. Will need new Biocontainer too.