### PR TITLE
Feature/scmap update

### DIFF
--- a/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
+++ b/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
@@ -1,0 +1,26 @@
+<tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+galaxy0"  python_template_version="3.5">
+    <description>Create final output in standard format to allow for downstream analysis of predicted labels</description>
+    <macros>
+         <import>scmap_macros.xml</import>
+    </macros>
+    <expand macro="requirements" />
+    <command detect_errors="exit_code"><![CDATA[
+        scmap_get_std_output.R --predictions-file "${input_predictions_file}" --output-table "${output_predictions_file}" --include-scores "${include_scores}" --sim-col-name "${sim_col_name}"
+    ]]></command>
+    <inputs>
+        <param type="data" name="input_predictions_file" label="Scmap predictions file in text format" format="txt" help="Path to the predictions file in text format" />
+        <param type="boolean" name="include_scores" checked="false"  label="Should prediction scores be included?" help="Boolean indicating whether similarity scores should be included in the final output" />
+        <param type="text" name="sim_col_name" value="scmap_cluster_siml" label="Column name of similarity scores" help="Name of column that contains distances between clusters/cells" />
+    </inputs>
+    <outputs>
+        <data name="output_predictions_file" format="txt" />
+    </outputs>
+    <help><![CDATA[
+    @HELP@
+    
+    @VERSION_HISTORY@
+    ]]></help>
+    <expand macro="citations" />
+</tool>
+
+

--- a/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
+++ b/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+galaxy0"  python_template_version="3.5">
+<tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+galaxy0"  profile="@PROFILE@">
     <description>Create final output in standard format to allow for downstream analysis of predicted labels</description>
     <macros>
          <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
+++ b/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
@@ -1,5 +1,5 @@
 <tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+galaxy0"  profile="@PROFILE@">
-    <description>Create final output in standard format to allow for downstream analysis of predicted labels</description>
+    <description>Create final output in standard format to allow for downstream analysis of predicted labels by tools of the EBI gene expression group's cell-types-analysis package</description>
     <macros>
          <import>scmap_macros.xml</import>
     </macros>
@@ -23,8 +23,14 @@
         </test>
     </tests>
     <help><![CDATA[
-    @HELP@
-    
+    Generate output tables in tab-separated format compatible with input specified in cell-types-analysis package: https://github.com/ebi-gene-expression-group/cell-types-analysis. 
+
+    See the example snippet below: 
+    ________________________________________
+    |  cell_id   | predicted_label | score |
+    | ERR2632411 | memory B cell   |  0.8  |
+    ...
+
     @VERSION_HISTORY@
     ]]></help>
     <expand macro="citations" />

--- a/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
+++ b/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+galaxy0"  profile="@PROFILE@">
+<tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+@GALAXY_VERSION@"  profile="@PROFILE@">
     <description>Create final output in standard format to allow for downstream analysis of predicted labels by tools of the EBI gene expression group's cell-types-analysis package</description>
     <macros>
          <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
+++ b/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
@@ -15,6 +15,13 @@
     <outputs>
         <data name="output_predictions_file" format="txt" />
     </outputs>
+    <tests>
+        <test>
+            <param name="input_predictions_file" value="project_cluster.csv" />
+            <param name="include_scores" value="TRUE" />
+            <output name="output_predictions_file" value="scmap_output_tbl.txt" compare="sim_size" />
+        </test>
+    </tests>
     <help><![CDATA[
     @HELP@
     

--- a/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
+++ b/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
@@ -1,5 +1,10 @@
-<tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+@GALAXY_VERSION@"  profile="@PROFILE@">
+<<<<<<< HEAD
+<tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+galaxy1"  profile="@PROFILE@">
     <description>Create final output in standard format to allow for downstream analysis of predicted labels by tools of the EBI gene expression group's cell-types-analysis package</description>
+=======
+<tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+galaxy0"  profile="@PROFILE@">
+    <description>Create final output in standard format to allow for downstream analysis of predicted labels</description>
+>>>>>>> parent of 2ccbd39... implement PR feedback
     <macros>
          <import>scmap_macros.xml</import>
     </macros>
@@ -23,14 +28,8 @@
         </test>
     </tests>
     <help><![CDATA[
-    Generate output tables in tab-separated format compatible with input specified in cell-types-analysis package: https://github.com/ebi-gene-expression-group/cell-types-analysis. 
-
-    See the example snippet below: 
-    ________________________________________
-    |  cell_id   | predicted_label | score |
-    | ERR2632411 | memory B cell   |  0.8  |
-    ...
-
+    @HELP@
+    
     @VERSION_HISTORY@
     ]]></help>
     <expand macro="citations" />

--- a/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
+++ b/tools/tertiary-analysis/scmap/scmap_get_std_output.xml
@@ -1,10 +1,5 @@
-<<<<<<< HEAD
 <tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+galaxy1"  profile="@PROFILE@">
     <description>Create final output in standard format to allow for downstream analysis of predicted labels by tools of the EBI gene expression group's cell-types-analysis package</description>
-=======
-<tool id="scmap_get_std_output" name="scmap get standard output" version="@TOOL_VERSION@+galaxy0"  profile="@PROFILE@">
-    <description>Create final output in standard format to allow for downstream analysis of predicted labels</description>
->>>>>>> parent of 2ccbd39... implement PR feedback
     <macros>
          <import>scmap_macros.xml</import>
     </macros>
@@ -28,7 +23,12 @@
         </test>
     </tests>
     <help><![CDATA[
-    @HELP@
+    Generate output tables in tab-separated format compatible with input specified in cell-types-analysis package: https://github.com/ebi-gene-expression-group/cell-types-analysis. 
+    See the example snippet below: 
+    ________________________________________
+    |  cell_id   | predicted_label | score |
+    | ERR2632411 | memory B cell   |  0.8  |
+    ...
     
     @VERSION_HISTORY@
     ]]></help>

--- a/tools/tertiary-analysis/scmap/scmap_index_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cell.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_index_cell" name="scmap index cells" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
+<tool id="scmap_index_cell" name="scmap index cells" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>creates a cell index for a dataset to enable fast approximate nearest neighbour search</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_index_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cell.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_index_cell" name="scmap index cells" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scmap_index_cell" name="scmap index cells" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
     <description>creates a cell index for a dataset to enable fast approximate nearest neighbour search</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_index_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cell.xml
@@ -5,7 +5,7 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
-        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}" && scmap-index-cell.R --input-object-file "preprocessed_${input_single_cell_experiment}" --number-chunks '$n_chunks' --number-clusters '$n_clusters' --output-object-file '$output_single_cell_experiment' --random-seed '$random_seed'
+        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "${input_single_cell_experiment}.preprocessed" && scmap-index-cell.R --input-object-file "${input_single_cell_experiment}.preprocessed" --number-chunks '$n_chunks' --number-clusters '$n_clusters' --output-object-file '$output_single_cell_experiment' --random-seed '$random_seed'
     ]]></command>
     <inputs>
         <param type="data" name="input_single_cell_experiment" label="SingleCellExperiment object" format="rdata" help="File with serialized SingleCellExperiment object as produced by 'scmap select features'" />
@@ -21,7 +21,7 @@
             <param name="n_chunks" value="50" />
             <param name="n_clusters" value="9" />
             <param name="input_single_cell_experiment" value="select_features.rds" ftype="rdata"/>
-            <output name="output_single_cell_experiment" file="index_cell.rds"/>
+            <output name="output_single_cell_experiment" file="index_cell.rds" compare="sim_size"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/tertiary-analysis/scmap/scmap_index_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cell.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_index_cell" name="scmap index cells" version="@TOOL_VERSION@+galaxy0" python_template_version="3.5">
+<tool id="scmap_index_cell" name="scmap index cells" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>creates a cell index for a dataset to enable fast approximate nearest neighbour search</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
@@ -5,7 +5,7 @@
     </macros>
     <expand macro="requirements" />
     <command detect_errors="exit_code"><![CDATA[
-        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "preprocessed_${input_single_cell_experiment}" && scmap-index-cluster.R --input-object-file "preprocessed_${input_single_cell_experiment}" --cluster-col '$cluster_col' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
+        scmap-preprocess-sce.R --input-object "${input_single_cell_experiment}" --output-sce-object "${input_single_cell_experiment}.preprocessed" && scmap-index-cluster.R --input-object-file "${input_single_cell_experiment}" --cluster-col '$cluster_col' --output-object-file '$output_single_cell_experiment' --output-plot-file '$plot'
     ]]></command>
     <inputs>
         <param type="data" name="input_single_cell_experiment" label="SingleCellExperiment object" format="rdata" help="File with serialized SingleCellExperiment object as produced by 'scmap select features'" />
@@ -18,7 +18,7 @@
     <tests>
         <test>
             <param name="input_single_cell_experiment" value="select_features.rds" ftype="rdata"/>
-            <output name="output_single_cell_experiment" file="index_cluster.rds"/>
+            <output name="output_single_cell_experiment" file="index_cluster.rds" compare="sim_size"/>
             <output name="plot" file="index_cluster.png"/>
         </test>
     </tests>

--- a/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_index_cluster" name="scmap index clusters" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
+<tool id="scmap_index_cluster" name="scmap index clusters" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>calculates centroids of each cell type and merges them into a single table</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_index_cluster" name="scmap index clusters" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scmap_index_cluster" name="scmap index clusters" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
     <description>calculates centroids of each cell type and merges them into a single table</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_index_cluster.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_index_cluster" name="scmap index clusters" version="@TOOL_VERSION@+galaxy0" python_template_version="3.5">
+<tool id="scmap_index_cluster" name="scmap index clusters" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>calculates centroids of each cell type and merges them into a single table</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_macros.xml
+++ b/tools/tertiary-analysis/scmap/scmap_macros.xml
@@ -1,6 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.6.0</token>
     <token name="@HELP@">More information can be found at https://bioconductor.org/packages/release/bioc/html/scmap.html</token>
+    <token name="@PROFILE@">18.01</token>
     <xml name="requirements">
       <requirements>
         <requirement type="package">openblas</requirement>

--- a/tools/tertiary-analysis/scmap/scmap_macros.xml
+++ b/tools/tertiary-analysis/scmap/scmap_macros.xml
@@ -5,7 +5,7 @@
       <requirements>
         <requirement type="package">openblas</requirement>
         <requirement type="package">bioconductor-delayedarray</requirement>
-        <requirement type="package" version="0.0.4">scmap-cli</requirement>
+        <requirement type="package" version="0.0.5">scmap-cli</requirement>
             <yield/>
       </requirements>
     </xml>

--- a/tools/tertiary-analysis/scmap/scmap_macros.xml
+++ b/tools/tertiary-analysis/scmap/scmap_macros.xml
@@ -4,8 +4,6 @@
     <token name="@PROFILE@">18.01</token>
     <xml name="requirements">
       <requirements>
-        <requirement type="package">openblas</requirement>
-        <requirement type="package">bioconductor-delayedarray</requirement>
         <requirement type="package" version="0.0.5">scmap-cli</requirement>
             <yield/>
       </requirements>

--- a/tools/tertiary-analysis/scmap/scmap_macros.xml
+++ b/tools/tertiary-analysis/scmap/scmap_macros.xml
@@ -1,6 +1,5 @@
 <macros>
     <token name="@TOOL_VERSION@">1.6.0</token>
-    <token name="@GALAXY_VERSION@">galaxy1</token>
     <token name="@HELP@">More information can be found at https://bioconductor.org/packages/release/bioc/html/scmap.html</token>
     <token name="@PROFILE@">18.01</token>
     <xml name="requirements">

--- a/tools/tertiary-analysis/scmap/scmap_macros.xml
+++ b/tools/tertiary-analysis/scmap/scmap_macros.xml
@@ -1,5 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.6.0</token>
+    <token name="@GALAXY_VERSION@">galaxy1</token>
     <token name="@HELP@">More information can be found at https://bioconductor.org/packages/release/bioc/html/scmap.html</token>
     <token name="@PROFILE@">18.01</token>
     <xml name="requirements">

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_scmap_cell" name="scmap cell projection" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scmap_scmap_cell" name="scmap cell projection" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
     <description>searches each cell in a query dataset for the nearest neighbours by cosine distance within a collection of reference datasets.</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
@@ -45,10 +45,10 @@
             <param name="index_single_cell_experiment" value="index_cell.rds" ftype="rdata"/>
             <param name="project_single_cell_experiment" value="test_sce.rds" ftype="rdata"/>
             <param name="cluster_projection" value="true" ftype="rdata"/>
-            <output name="output_single_cell_experiment" file="closest_cells_clusters.rds"/>
-            <output name="closest_cells_clusters_csv" file="closest_cells_clusters.csv" />
-            <output name="closest_cells_text_file" file="closest_cells.csv"/>
-            <output name="closest_cells_similarities_text_file" file="closest_cells_similarities.csv"/>
+            <output name="output_single_cell_experiment" file="closest_cells_clusters.rds" compare="sim_size"/>
+            <output name="closest_cells_clusters_csv" file="closest_cells_clusters.csv" compare="sim_size" />
+            <output name="closest_cells_text_file" file="closest_cells.csv" compare="sim_size"/>
+            <output name="closest_cells_similarities_text_file" file="closest_cells_similarities.csv" compare="sim_size"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_scmap_cell" name="scmap cell projection" version="@TOOL_VERSION@+galaxy0" python_template_version="3.5">
+<tool id="scmap_scmap_cell" name="scmap cell projection" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>searches each cell in a query dataset for the nearest neighbours by cosine distance within a collection of reference datasets.</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_scmap_cell" name="scmap cell projection" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
+<tool id="scmap_scmap_cell" name="scmap cell projection" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>searches each cell in a query dataset for the nearest neighbours by cosine distance within a collection of reference datasets.</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
@@ -20,8 +20,8 @@
         <test>
             <param name="index_single_cell_experiment" value="index_cluster.rds" ftype="rdata"/>
             <param name="project_single_cell_experiment" value="test_sce.rds" ftype="rdata"/>
-            <output name="output_single_cell_experiment" file="project_cluster.rds"/>
-            <output name="output_txt" file="project_cluster.csv"/>
+            <output name="output_single_cell_experiment" file="project_cluster.rds" compare="sim_size"/>
+            <output name="output_txt" file="project_cluster.csv" compare="sim_size"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_scmap_cluster" name="scmap cluster projection" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
+<tool id="scmap_scmap_cluster" name="scmap cluster projection" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>projects one dataset to another</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_scmap_cluster" name="scmap cluster projection" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scmap_scmap_cluster" name="scmap cluster projection" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
     <description>projects one dataset to another</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_scmap_cluster" name="scmap cluster projection" version="@TOOL_VERSION@+galaxy0" python_template_version="3.5">
+<tool id="scmap_scmap_cluster" name="scmap cluster projection" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>projects one dataset to another</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_select_features.xml
+++ b/tools/tertiary-analysis/scmap/scmap_select_features.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_select_features" name="scmap select features" version="@TOOL_VERSION@+galaxy0" python_template_version="3.5">
+<tool id="scmap_select_features" name="scmap select features" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>finds the most informative features (genes/transcripts) for projection.</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_select_features.xml
+++ b/tools/tertiary-analysis/scmap/scmap_select_features.xml
@@ -18,8 +18,8 @@
     <tests>
         <test>
             <param name="input_single_cell_experiment" value="test_sce.rds" ftype="rdata"/>
-            <output name="output_single_cell_experiment" file="select_features.rds"/>
-            <output name="plot" file="select_features.png"/>
+            <output name="output_single_cell_experiment" file="select_features.rds" compare="sim_size"/>
+            <output name="plot" file="select_features.png" compare="sim_size"/>
         </test>
     </tests>
     <help><![CDATA[

--- a/tools/tertiary-analysis/scmap/scmap_select_features.xml
+++ b/tools/tertiary-analysis/scmap/scmap_select_features.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_select_features" name="scmap select features" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scmap_select_features" name="scmap select features" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
     <description>finds the most informative features (genes/transcripts) for projection.</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_select_features.xml
+++ b/tools/tertiary-analysis/scmap/scmap_select_features.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_select_features" name="scmap select features" version="@TOOL_VERSION@+@GALAXY_VERSION@" profile="@PROFILE@">
+<tool id="scmap_select_features" name="scmap select features" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>finds the most informative features (genes/transcripts) for projection.</description>
     <macros>
         <import>scmap_macros.xml</import>


### PR DESCRIPTION
Modify scmap wrappers so that they would match an updated version of the tool. 

- Add tool for getting standardised tables compatible with `cell-types-analysis` package
- Add `compare="sim_size"` parameter to the tests so that produced outputs are checked to have a similar size to reference files. 