### PR TITLE
Fix labels in some scanpy tools

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
@@ -52,7 +52,7 @@ PYTHONIOENCODING=utf-8 scanpy-find-cluster
         <param name="use_graph" argument="--use-graph" value="neighbors" type="text"
             label="Name of the slot that holds the KNN graph"/>
         <param name="key_added" argument="--key-added" type="text" optional="true"
-            label="Additional suffix to the name of the slot to save the calculated trajectory"/>
+            label="Additional suffix to the name of the slot to save the calculated clustering"/>
 
         <param name="resolution" argument="--resolution" type="float" min="0.0" value="1.0"
                label="Resolution, high value for more and smaller clusters"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_cluster" name="Scanpy FindCluster" version="@TOOL_VERSION@+galaxy10" profile="@PROFILE@">
+<tool id="scanpy_find_cluster" name="Scanpy FindCluster" version="@TOOL_VERSION@+galaxy11" profile="@PROFILE@">
   <description>based on community detection on KNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
@@ -32,7 +32,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli embed diffmap
     <param name="use_graph" argument="--use-graph" value="neighbors" type="text"
            label="Name of the slot that holds the KNN graph"/>
     <param name="key_added" argument="--key-added" type="text" optional="true"
-           label="Additional suffix to the name of the slot to save the calculated trajectory"/>
+           label="Additional suffix to the name of the slot to save the calculated diffusion map"/>
   </inputs>
 
   <outputs>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_diffmap" name="Scanpy DiffusionMap" version="@TOOL_VERSION@+galaxy10" profile="@PROFILE@">
+<tool id="scanpy_run_diffmap" name="Scanpy DiffusionMap" version="@TOOL_VERSION@+galaxy11" profile="@PROFILE@">
   <description>calculate diffusion components</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_dpt" name="Scanpy DPT" version="@TOOL_VERSION@+galaxy10" profile="@PROFILE@">
+<tool id="scanpy_run_dpt" name="Scanpy DPT" version="@TOOL_VERSION@+galaxy11" profile="@PROFILE@">
   <description>diffusion pseudotime inference</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
@@ -42,7 +42,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli dpt
     <param name="use_graph" argument="--use-graph" value="neighbors" type="text"
            label="Name of the slot that holds the KNN graph"/>
     <param name="key_added" argument="--key-added" type="text" optional="true"
-           label="Additional suffix to the name of the slot to save the calculated trajectory"/>
+           label="Additional suffix to the name of the slot to save the calculated pseudo-time"/>
   </inputs>
 
   <outputs>


### PR DESCRIPTION
This PR fixes copy-paste errors in the option labels of a few scanpy tools.