### PR TITLE
Citation to preprint on all tools

### DIFF
--- a/tools/droplet-barcode-plot/dropletBarcodePlot.xml
+++ b/tools/droplet-barcode-plot/dropletBarcodePlot.xml
@@ -76,5 +76,6 @@ publisher = {GitHub},
 journal = {GitHub repository},
 url = {https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary},
   }</citation>
+  <citation type="doi">10.1101/2020.04.08.032698</citation>
 </citations>
 </tool>

--- a/tools/gtf-2-gene-list/gtf2featureAnnotation.xml
+++ b/tools/gtf-2-gene-list/gtf2featureAnnotation.xml
@@ -92,5 +92,6 @@ publisher = {GitHub},
 journal = {GitHub repository},
 url = {https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary},
   }</citation>
+  <citation type="doi">10.1101/2020.04.08.032698</citation>
 </citations>
 </tool>

--- a/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
+++ b/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
@@ -66,5 +66,6 @@ publisher = {GitHub},
 journal = {GitHub repository},
 url = {https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary},
   }</citation>
+  <citation type="doi">10.1101/2020.04.08.032698</citation>
 </citations>
 </tool>

--- a/tools/tertiary-analysis/cell-types-analysis/ct_macros.xml
+++ b/tools/tertiary-analysis/cell-types-analysis/ct_macros.xml
@@ -29,6 +29,7 @@
             url = {https://github.com/ebi-gene-expression-group/cell-types-analysis.git},
           }
         </citation>
+        <citation type="doi">10.1101/2020.04.08.032698</citation>
         <yield />
       </citations>
     </xml>

--- a/tools/tertiary-analysis/data-hca/matrix-service.xml
+++ b/tools/tertiary-analysis/data-hca/matrix-service.xml
@@ -104,5 +104,6 @@ Outputs will be:
 ]]></help>
   <citations>
     <citation type="doi">10.7554/eLife.27041</citation>
+    <citation type="doi">10.1101/2020.04.08.032698</citation>
   </citations>
 </tool>

--- a/tools/tertiary-analysis/data-scxa/retrieve-scxa.xml
+++ b/tools/tertiary-analysis/data-scxa/retrieve-scxa.xml
@@ -114,5 +114,6 @@ Outputs will be:
 ]]></help>
   <citations>
     <citation type="doi">10.1093/nar/gkv1045</citation>
+    <citation type="doi">10.1101/2020.04.08.032698</citation>
   </citations>
 </tool>

--- a/tools/tertiary-analysis/dropletutils/dropletutils_macros.xml
+++ b/tools/tertiary-analysis/dropletutils/dropletutils_macros.xml
@@ -18,6 +18,7 @@
   <xml name="citations">
     <citations>
       <citation type="doi">10.1101/234872</citation>
+      <citation type="doi">10.1101/2020.04.08.032698</citation>
     </citations>
   </xml>
 </macros>

--- a/tools/tertiary-analysis/garnett/garnett_macros.xml
+++ b/tools/tertiary-analysis/garnett/garnett_macros.xml
@@ -21,7 +21,7 @@
         <citations>
             <citation type="bibtex">
                 @article{,
-                url = {https://doi.org/10.1038/s41592-019-0535-3},           
+                url = {https://doi.org/10.1038/s41592-019-0535-3},
                 author = {Hannah A. Pliner and Jay Shendure and Cole Trapnell},
                 title = {Supervised classification enables rapid annotation of cell atlases},
                 journal = {Nature Methods}
@@ -38,7 +38,7 @@
                   }
             </citation>
             <yield />
+            <citation type="doi">10.1101/2020.04.08.032698</citation>
         </citations>
     </xml>
 </macros>
-

--- a/tools/tertiary-analysis/monocle3/monocle3-macros.xml
+++ b/tools/tertiary-analysis/monocle3/monocle3-macros.xml
@@ -46,6 +46,7 @@
 	journal = {GitHub repository},
 	url = {https://github.com/ebi-gene-expression-group/monocle-scripts},
       }</citation>
+      <citation type="doi">10.1101/2020.04.08.032698</citation>
     </citations>
   </xml>
 

--- a/tools/tertiary-analysis/sc3/sc3-macros.xml
+++ b/tools/tertiary-analysis/sc3/sc3-macros.xml
@@ -25,6 +25,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
         journal = {GitHub repository},
         url = {https://github.com/ebi-gene-expression-group/bioconductor-sc3-scripts.git},
       }</citation>
+      <citation type="doi">10.1101/2020.04.08.032698</citation>
       <yield />
     </citations>
   </xml>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -64,6 +64,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 	journal = {GitHub repository},
 	url = {https://github.com/ebi-gene-expression-group/scanpy-scripts},
       }</citation>
+      <citation type="doi">10.1101/2020.04.08.032698</citation>
     </citations>
   </xml>
 

--- a/tools/tertiary-analysis/scater/scater_macros.xml
+++ b/tools/tertiary-analysis/scater/scater_macros.xml
@@ -46,6 +46,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and and Teichmann Lab at Wellcome Sanger Institu
         url = {https://github.com/ebi-gene-expression-group/bioconductor-scater-scripts.git},
       }
       </citation>
+      <citation type="doi">10.1101/2020.04.08.032698</citation>
       <yield />
     </citations>
   </xml>

--- a/tools/tertiary-analysis/sccaf/sccaf_macros.xml
+++ b/tools/tertiary-analysis/sccaf/sccaf_macros.xml
@@ -63,6 +63,7 @@ characterised by the feature genes as markers.
 	journal = {GitHub repository},
 	url = {https://github.com/Functional-Genomics/SCCAF},
       }</citation>
+      <citation type="doi">10.1101/2020.04.08.032698</citation>
       <yield />
     </citations>
   </xml>

--- a/tools/tertiary-analysis/sceasy/sceasy_macros.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_macros.xml
@@ -17,6 +17,7 @@
   <xml name="citations">
     <citations>
       <yield />
+      <citation type="doi">10.1101/2020.04.08.032698</citation>
       <!-- <citation type="doi"> </citation> -->
       <!-- <citation type="bibtex"> </citation> -->
     </citations>

--- a/tools/tertiary-analysis/scmap/scmap_macros.xml
+++ b/tools/tertiary-analysis/scmap/scmap_macros.xml
@@ -38,6 +38,7 @@
             url = {https://github.com/ebi-gene-expression-group/scmap-cli.git},
           }
         </citation>
+        <citation type="doi">10.1101/2020.04.08.032698</citation>
         <yield />
       </citations>
     </xml>

--- a/tools/tertiary-analysis/scpred/scpred_macros.xml
+++ b/tools/tertiary-analysis/scpred/scpred_macros.xml
@@ -37,10 +37,9 @@
                 journal = {GitHub repository},
                 url = {https://github.com/ebi-gene-expression-group/scpred-cli.git},
               }
-
             </citation>
+            <citation type="doi">10.1101/2020.04.08.032698</citation>
             <yield />
         </citations>
     </xml>
 </macros>
-

--- a/tools/tertiary-analysis/seurat/seurat_macros.xml
+++ b/tools/tertiary-analysis/seurat/seurat_macros.xml
@@ -121,6 +121,7 @@ EMBL-EBI https://www.ebi.ac.uk/. Parts obtained from wrappers from Christophe An
               url = {https://github.com/ebi-gene-expression-group/r-seurat-scripts.git},
             }
             </citation>
+            <citation type="doi">10.1101/2020.04.08.032698</citation>
         </citations>
     </xml>
 </macros>

--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -116,5 +116,6 @@ EMBL-EBI https://www.ebi.ac.uk/.
   url = {https://github.com/maximilianh/cellBrowser},
  }
  </citation>
+ <citation type="doi">10.1101/2020.04.08.032698</citation>
 </citations>
 </tool>


### PR DESCRIPTION
This adds the DOI of the tools preprint to the citations of all tools. I have asked on Galaxy gitter, and I was told that for small doc changes, they don't usually bump the `+galaxy<num>` version, so haven't done so.