### PR TITLE
CellBrowser redirect

### DIFF
--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -1,7 +1,7 @@
-<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.7.9+galaxy0" profile="18.01">
+<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.5.43+galaxy1" profile="18.01">
   <description>displays single-cell clusterized data in an interactive web application.</description>
   <requirements>
-    <requirement type="package" version="0.7.9">ucsc-cell-browser</requirement>
+    <requirement type="package" version="0.5.43">ucsc-cell-browser</requirement>
   </requirements>
 <stdio>
 <exit_code range="1:" />
@@ -26,12 +26,12 @@
 
 #else if $input_type.expression_source == "scanpy":
 
+   ## We could add a condition here were, if cluster_field is provided
+   ## then we rename it inside with an AnnData relying script to read 'louvain' to please UCSC CellBrowser
+
    ln -s '$input_anndata_file' scanpy_ann_data.h5ad;
    cbImportScanpy -i scanpy_ann_data.h5ad
 
-   #if $cluster_field:
-     --clusterField '$cluster_field'
-   #end if
    #if $marker_field:
      --markerField '$marker_field'
    #end if
@@ -60,8 +60,10 @@
       <param name="input_anndata_file" type="data" format="h5,h5ad" label="Input object in AnnData hdf5 format" help="Scanpy serialized output is by default produced as an AnnData hdf5 file."/>
     </when>
   </conditional>
+  <!-- if I put these vvv two inside the when scanpy, these for some reason don't get picked ¿? -->
   <param name="cluster_field" argument="--clusterField" type="text" label="Cluster field" help="Scanpy cluster field to use, optional, if not set 'louvain' will be used."/>
-  <param name="marker_field" argument="--markerField" type="text" label="Marker genes field" help="Scanpy marker genes field to use, optional, if not set 'rank_genes_groups' will be used."/>
+  <param name="marker_field" argument="--markerField" type="text" value="rank_genes_groups" label="Marker genes field" help="Scanpy marker genes field to use, optional, if not set 'rank_genes_groups' will be used."/>
+  <!-- if I put these ^^^ two inside the when scanpy, these for some reason don't get picked ¿? -->
 </inputs>
 <outputs>
     <data format="html" name="html_file" label="Interactive UCSC Cell Browser"/>

--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -1,7 +1,7 @@
-<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.5.43+galaxy0">
+<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.7.9+galaxy0" profile="18.01">
   <description>displays single-cell clusterized data in an interactive web application.</description>
   <requirements>
-    <requirement type="package" version="0.5.43">ucsc-cell-browser</requirement>
+    <requirement type="package" version="0.7.9">ucsc-cell-browser</requirement>
   </requirements>
 <stdio>
 <exit_code range="1:" />
@@ -9,7 +9,7 @@
 <command><![CDATA[
 #if $input_type.expression_source == "native-cell-browser":
 
-   echo "coords = [ {'file':'$tsneCoordinates', 'shortLabel':'t-SNE on WGCNA'} ]" > ./cellbrowser.conf;
+   echo "coords = [ {'file':'$tsneCoordinates', 'shortLabel':'t-SNE'} ]" > ./cellbrowser.conf;
    echo "meta = '$cellMetadata'" >> ./cellbrowser.conf;
    echo "name = 'sample'" >> ./cellbrowser.conf;
    echo "exprMatrix = '$expressionMatrix'" >> ./cellbrowser.conf;
@@ -27,8 +27,17 @@
 #else if $input_type.expression_source == "scanpy":
 
    ln -s '$input_anndata_file' scanpy_ann_data.h5ad;
-   cbImportScanpy -i scanpy_ann_data.h5ad -o outdir -n sample --htmlDir "$html_file.extra_files_path";
-   mv "$html_file.extra_files_path"/index.html "$html_file";
+   cbImportScanpy -i scanpy_ann_data.h5ad
+
+   #if $cluster_field:
+     --clusterField '$cluster_field'
+   #end if
+   #if $marker_field:
+     --markerField '$marker_field'
+   #end if
+
+     -o outdir -n sample --htmlDir "$html_file.extra_files_path";
+   mv "$__tool_directory__/redirect.html" "$html_file";
 
 #end if
 ]]></command>
@@ -48,9 +57,11 @@
       <param name="tarred_sources" type="data" format="tar" label="CellBrowser source files tarred" help="Tar containing CellBrowser config, tsne, umap and other source files for running cbBuild"/>
     </when>
     <when value="scanpy">
-      <param name="input_anndata_file" type="data" format="h5" label="Input object in AnnData hdf5 format" help="Scanpy serialized output is by default produced as an AnnData hdf5 file."/>
+      <param name="input_anndata_file" type="data" format="h5,h5ad" label="Input object in AnnData hdf5 format" help="Scanpy serialized output is by default produced as an AnnData hdf5 file."/>
     </when>
   </conditional>
+  <param name="cluster_field" argument="--clusterField" type="text" label="Cluster field" help="Scanpy cluster field to use, optional, if not set 'louvain' will be used."/>
+  <param name="marker_field" argument="--markerField" type="text" label="Marker genes field" help="Scanpy marker genes field to use, optional, if not set 'rank_genes_groups' will be used."/>
 </inputs>
 <outputs>
     <data format="html" name="html_file" label="Interactive UCSC Cell Browser"/>

--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -16,13 +16,19 @@
    echo "geneIdType = 'symbol'" >> ./cellbrowser.conf;
 
    cbBuild -i cellbrowser.conf -o "$html_file.extra_files_path";
-   mv "$html_file.extra_files_path"/index.html "$html_file";
+
+   ## "sample" is used as name, so no change needed.
+   cp '$__tool_directory__/redirect.html' '$html_file';
 
 #else if $input_type.expression_source == "cell-browser-tar":
 
    tar -xf '$tarred_sources';
    cbBuild -i cellbrowser.conf -o "$html_file.extra_files_path";
-   mv "$html_file.extra_files_path"/index.html "$html_file";
+
+   ## we need to adapt redirect to use the study name used in cellbrowser.conf
+   study=\$(grep '^name=' cellbrowser.conf | awk -F'=' '{ print $2 }' | sed s/\"//g ) &&
+   echo "Study to replace: "\$study &&
+   sed "s/ds=sample/ds=\$study/" '$__tool_directory__/redirect.html' > '$html_file';
 
 #else if $input_type.expression_source == "scanpy":
 
@@ -36,8 +42,8 @@
      --markerField '$marker_field'
    #end if
 
-     -o outdir -n sample --htmlDir "$html_file.extra_files_path";
-   cp "$__tool_directory__/redirect.html" "$html_file";
+     -o outdir -n sample --htmlDir '$html_file.extra_files_path';
+   cp '$__tool_directory__/redirect.html' '$html_file';
 
 #end if
 ]]></command>

--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -1,7 +1,7 @@
-<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.5.43+galaxy1" profile="18.01">
+<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.7.9+galaxy1" profile="18.01">
   <description>displays single-cell clusterized data in an interactive web application.</description>
   <requirements>
-    <requirement type="package" version="0.5.43">ucsc-cell-browser</requirement>
+    <requirement type="package" version="0.7.9">ucsc-cell-browser</requirement>
   </requirements>
 <stdio>
 <exit_code range="1:" />
@@ -37,7 +37,7 @@
    #end if
 
      -o outdir -n sample --htmlDir "$html_file.extra_files_path";
-   mv "$__tool_directory__/redirect.html" "$html_file";
+   cp "$__tool_directory__/redirect.html" "$html_file";
 
 #end if
 ]]></command>

--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -38,8 +38,8 @@
    ln -s '$input_anndata_file' scanpy_ann_data.h5ad;
    cbImportScanpy -i scanpy_ann_data.h5ad
 
-   #if $marker_field:
-     --markerField '$marker_field'
+   #if $input_type.marker_field:
+     --markerField '${input_type.marker_field}'
    #end if
 
      -o outdir -n sample --htmlDir '$html_file.extra_files_path';
@@ -64,15 +64,12 @@
     </when>
     <when value="scanpy">
       <param name="input_anndata_file" type="data" format="h5,h5ad" label="Input object in AnnData hdf5 format" help="Scanpy serialized output is by default produced as an AnnData hdf5 file."/>
+      <param name="marker_field" argument="--markerField" type="text" value="rank_genes_groups" label="Marker genes field" help="Scanpy marker genes field to use, optional, if not set 'rank_genes_groups' will be used."/>
     </when>
   </conditional>
-  <!-- if I put these vvv two inside the when scanpy, these for some reason don't get picked ¿? -->
-  <param name="cluster_field" argument="--clusterField" type="text" label="Cluster field" help="Scanpy cluster field to use, optional, if not set 'louvain' will be used."/>
-  <param name="marker_field" argument="--markerField" type="text" value="rank_genes_groups" label="Marker genes field" help="Scanpy marker genes field to use, optional, if not set 'rank_genes_groups' will be used."/>
-  <!-- if I put these ^^^ two inside the when scanpy, these for some reason don't get picked ¿? -->
 </inputs>
 <outputs>
-    <data format="html" name="html_file" label="Interactive UCSC Cell Browser"/>
+    <data format="html" name="html_file" label="${tool.name} on ${on_string}: Interactive Viewer"/>
 </outputs>
 
 <tests>

--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -1,7 +1,7 @@
-<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.7.9+galaxy1" profile="18.01">
+<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="0.5.43+galaxy1" profile="18.01">
   <description>displays single-cell clusterized data in an interactive web application.</description>
   <requirements>
-    <requirement type="package" version="0.7.9">ucsc-cell-browser</requirement>
+    <requirement type="package" version="0.5.43">ucsc-cell-browser</requirement>
   </requirements>
 <stdio>
 <exit_code range="1:" />

--- a/tools/tertiary-analysis/ucsc-cell-browser/redirect.html
+++ b/tools/tertiary-analysis/ucsc-cell-browser/redirect.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0; url=index.html?ds=sample">
+        <script type="text/javascript">
+            window.location.href = "index.html?ds=sample"
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
+        If you are not redirected automatically, follow this <a href='index.html?ds=sample'>link to example</a>.
+    </body>
+</html>


### PR DESCRIPTION
This PR adds a trick to redirect directly to the CellBrowser study, skipping the javascript error in 
 Galaxy >19.05. It also exposes marker genes field. 