### PR TITLE
Add n_neighbors option to Scanpy iterator

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
@@ -1,4 +1,4 @@
-<tool id="scanpy_parameter_iterator" name="Scanpy ParameterIterator" version="0.0.1+galaxy1">
+<tool id="scanpy_parameter_iterator" name="Scanpy ParameterIterator" version="0.0.1+galaxy2">
     <description>produce an iteration over a defined parameter</description>
     <macros>
       <import>scanpy_macros.xml</import>
@@ -23,6 +23,7 @@
       <param type="select" name="parameter_name" label="Choose the format of the expression data" help="Use compressed txt, Scanpy or Seurat objects">
         <option value="perplexity" selected="True">Perplexity</option>
         <option value="resolution">Resolution</option>
+        <option value="n_neighbours">Number of neighbours</option>
       </param> 
       <conditional name="input_type">    
         <param type="select" name="parameter_values" label="Choose the format of the input values" help="step increase values or list of all the parameter values">
@@ -66,8 +67,8 @@
 
 **What it does**
 
-Given start, step and end, it will iterate parameters for either perplexity or
-resolution.
+Given start, step and end, it will iterate parameters for either perplexity (for t-SNE), resolution (clustering)
+or number of neighbours (neighbour graph construction).
 
 **Inputs**
 

--- a/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
@@ -23,7 +23,7 @@
       <param type="select" name="parameter_name" label="Choose the format of the expression data" help="Use compressed txt, Scanpy or Seurat objects">
         <option value="perplexity" selected="True">Perplexity</option>
         <option value="resolution">Resolution</option>
-        <option value="n_neighbours">Number of neighbours</option>
+        <option value="n_neighbors">Number of neighbors</option>
       </param> 
       <conditional name="input_type">    
         <param type="select" name="parameter_values" label="Choose the format of the input values" help="step increase values or list of all the parameter values">

--- a/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
@@ -20,7 +20,7 @@
 	    ]]></command>
 
     <inputs>
-      <param type="select" name="parameter_name" label="Choose the format of the expression data" help="Use compressed txt, Scanpy or Seurat objects">
+      <param type="select" name="parameter_name" label="Choose the parameter to iterate" help="Select one of the available parameters to iterate, will affect names of output files">
         <option value="perplexity" selected="True">Perplexity</option>
         <option value="resolution">Resolution</option>
         <option value="n_neighbors">Number of neighbors</option>

--- a/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
@@ -20,7 +20,7 @@
 	    ]]></command>
 
     <inputs>
-      <param type="select" name="parameter_name" label="Choose the parameter to iterate" help="Select one of the available parameters to iterate, will affect names of output files">
+      <param type="select" name="parameter_name" label="Choose the format of the expression data" help="Use compressed txt, Scanpy or Seurat objects">
         <option value="perplexity" selected="True">Perplexity</option>
         <option value="resolution">Resolution</option>
         <option value="n_neighbors">Number of neighbors</option>

--- a/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
@@ -20,7 +20,7 @@
 	    ]]></command>
 
     <inputs>
-      <param type="select" name="parameter_name" label="Choose the format of the expression data" help="Use compressed txt, Scanpy or Seurat objects">
+      <param type="select" name="parameter_name" label="Parameter name" help="Select a type of parameter">
         <option value="perplexity" selected="True">Perplexity</option>
         <option value="resolution">Resolution</option>
         <option value="n_neighbors">Number of neighbors</option>


### PR DESCRIPTION
Seems like this tool should be more generic and not require hard-coded parameter types, but for now I've just added n_neighbors for the new umap functions. 