### PR TITLE
Enable copy of uns in AnnData merger

### DIFF
--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="anndata_ops" name="AnnData Operations" version="0.0.2+galaxy0" profile="@PROFILE@">
+<tool id="anndata_ops" name="AnnData Operations" version="0.0.3+galaxy0" profile="@PROFILE@">
   <description>modifies metadata and flags genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -19,6 +19,12 @@ ln -s '${input_obj_file}' input.h5 &&
   ln -s '${es}' embedding_source_${i}.h5 &&
 #end for
 #end if
+
+#if $copy_u.default:
+#for $i, $us in enumerate($copy_u.uns_sources):
+  ln -s '${us}' uns_source_${i}.h5 &&
+#end for
+#end if
 python $operations
 ]]></command>
   <configfiles>
@@ -35,6 +41,9 @@ qc_vars = list()
 
 #for $i, $s in enumerate($modifications)
 adata.obs['${s.to_obs}'] = adata.obs['${s.from_obs}']
+#if not $s.keep_original:
+del adata.obs[${s.from_obs}']
+#end if
 #end for
 
 gene_names = getattr(adata.var, gene_name)
@@ -79,6 +88,20 @@ else:
 #end for
 #end if
 
+#if $copy_u.default and len($copy_u.uns_keys) > 0:
+#for $i, $uns_s in enumerate($copy_u.uns_sources):
+ad_s = sc.read('uns_source_${i}.h5')
+if adata.n_obs == ad_s.n_obs and all(adata.obs_names == ad_s.obs_names):
+  #for $j, $u_key in enumerate($copy_u.uns_keys):
+  keys_to_copy = (k for k in ad_s.uns.keys() if "${u_key.contains}" in k)
+  for k_to_copy in keys_to_copy:
+    adata.uns[k_to_copy+"_${i}"] = ad_s.uns[k_to_copy]
+  #end for
+else:
+  logging.warning("Uns source ${i} AnnData file is not compatible to be merged to main AnnData file, different cell names.")
+#end for
+#end if
+
 #if $sanitize_varm:
 if hasattr(adata, 'raw') and  hasattr(adata.raw, 'X') and hasattr(adata.raw, 'var'):
   new_ad = anndata.AnnData(X=adata.raw.X, obs=adata.obs, var=adata.raw.var)
@@ -112,6 +135,7 @@ adata.write('output.h5', compression='gzip')
         </sanitizer>
       </param>
       <param name="to_obs" type="text" label="New name" help="New name in observations that you want to change"/>
+      <param name="keep_original" type="boolean" lable="Keep original" help="If activated, it will also keep the original column" checked="false"/>
     </repeat>
     <param name="gene_symbols_field" value='index' type="text" label="Gene symbols field in AnnData" help="Field inside var.params where the gene symbols are, normally 'index' or 'gene_symbols'"/>
     <repeat name="gene_flags" title="Flag genes that start with these names">
@@ -122,7 +146,7 @@ adata.write('output.h5', compression='gzip')
     <conditional name="copy_o">
       <param name="default" type="boolean" checked="false" label="Copy observations (such as clusters)"/>
       <when value="true">
-        <repeat name="obs_keys" title="Keys from obs to copy" help="will copy all obs keys in the given AnnData object to the main AnnData object. Make sure to use AnnData objects that are compatible in terms of genes, cells and expression data. You can use this to copy clusters." min="1">
+        <repeat name="obs_keys" title="Keys from obs to copy" help="will copy all obs keys in the given AnnData object to the main AnnData object. Make sure to use AnnData objects that are compatible in terms of genes, cells and expression data. You can use this to copy clusters. Uns elements with the same name will be also transferred." min="1">
           <param name="contains" type="text" label="Key contains" help="Keys to be copied need to contain the text set here."/>
         </repeat>
         <param name="obs_sources" type="data" label="AnnData objects with obs to copy" help="Extracts obs (such as clusters) from these AnnData objects and merges them into the main input. Make sure to use AnnData objects that are compatible in terms of genes, cells and expression data." format="h5,h5ad" multiple="true"/>
@@ -140,6 +164,15 @@ adata.write('output.h5', compression='gzip')
         <!-- <param name="check_e" type="boolean" label="Check compatibility" help="checks if the provided AnnData objects are compatible (same genes and cells) for merging." checked="true"/> -->
       </when>
       <when value="false"/>
+    </conditional>
+    <conditional name="copy_u">
+      <param name="default" type="boolean" checked="false" label="Copy uns"/>
+      <when value="true">
+        <repeat name="uns_keys" title="Keys from uns to copy" help="will copy all uns keys in the given AnnData object to the main AnnData object. Make sure to use AnnData objects that are compatible in terms of genes, cells and expression data. You can use this to copy rank_genes_groups for instance." min="1">
+          <param name="contains" type="text" label="Key contains" help="Keys to be copied need to contain the text set here."/>
+        </repeat>
+        <param name="uns_sources" type="data" label="AnnData objects with uns to copy" help="Extracts uns (such as ranked_genes_groups) from these AnnData objects and merges them into the main input. Make sure to use AnnData objects that are compatible in terms of genes, cells and expression data." format="h5,h5ad" multiple="true"/>
+      </when>
     </conditional>
     <param name="sanitize_varm" type="boolean" checked="false" label="Sanitise any null raw.varm objects if any" help="This might be relevant for interfacing with newer versions of AnnData, that might complain if .raw includes a varm null object."/>
   </inputs>
@@ -169,6 +202,10 @@ Performs the following operations:
 * For the flags created, calculates qc metrics (pct_<flag>_counts).
 * Calculates `n_genes`, `n_counts` for cells and `n_cells`, `n_counts` for genes.
 * For top <N> genes specified, calculate qc metrics (pct_counts_in_top_<N>_genes).
+* Copy from a set of compatible AnnData objects (same cells and genes):
+  * Observations, such as clustering results.
+  * Embeddings, such as tSNE or UMAPs.
+  * Unstructure annotations, like gene markers.
 
 This functionality will probably be added in the future to a larger package.
 ]]></help>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -42,7 +42,7 @@ qc_vars = list()
 #for $i, $s in enumerate($modifications)
 adata.obs['${s.to_obs}'] = adata.obs['${s.from_obs}']
 #if not $s.keep_original:
-del adata.obs[${s.from_obs}']
+del adata.obs['${s.from_obs}']
 #end if
 #end for
 

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -135,7 +135,7 @@ adata.write('output.h5', compression='gzip')
         </sanitizer>
       </param>
       <param name="to_obs" type="text" label="New name" help="New name in observations that you want to change"/>
-      <param name="keep_original" type="boolean" lable="Keep original" help="If activated, it will also keep the original column" checked="false"/>
+      <param name="keep_original" type="boolean" label="Keep original" help="If activated, it will also keep the original column" checked="false"/>
     </repeat>
     <param name="gene_symbols_field" value='index' type="text" label="Gene symbols field in AnnData" help="Field inside var.params where the gene symbols are, normally 'index' or 'gene_symbols'"/>
     <repeat name="gene_flags" title="Flag genes that start with these names">


### PR DESCRIPTION
This adds uns to the potential objects that can be copied from one AnnData to another.