### PR TITLE
dropletutils: add option to provide metadata file

### DIFF
--- a/tools/tertiary-analysis/dropletutils/dropletutils-read-10x.xml
+++ b/tools/tertiary-analysis/dropletutils/dropletutils-read-10x.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="dropletutils_read_10x" name="DropletUtils Read10x" version="@TOOL_VERSION@+galaxy0">
+<tool id="dropletutils_read_10x" name="DropletUtils Read10x" version="@TOOL_VERSION@+galaxy1">
   <description>into SingleCellExperiment object</description>
   <macros>
     <import>dropletutils_macros.xml</import>
@@ -13,12 +13,32 @@ dropletutils-read-10x-counts.R
     -s .
     -c TRUE
     -o '${output_rds}'
+
+#if $metadata_files 
+--metadata-files "${metadata_files}" 
+#end if
+#if $cell_id_column 
+--cell-id-column "${cell_id_column}" 
+#end if
+
+
 ]]></command>
 
   <inputs>
     <param name="matrix" type="data" format="txt" label="Expression matrix in sparse matrix format (.mtx)"/>
     <param name="genes" type="data" format="tsv,tabular" label="Gene table"/>
     <param name="barcodes" type="data" format="tsv,tabular" label="Barcode/cell table"/>
+    <conditional name="add_metadata">
+        <param name="add_metadata_file" type="boolean" checked="false" label="Should metadata file be added?" />
+        <when value="true" >
+          <param name="metadata_files" type="data" label="Metadata file" help="Provide metadata file e.g. containing cell types"/>
+          <param name="cell_id_column" type="text" label="Cell ID column" help="Cell ID column. Values must match those provided in the expression matrix." />
+        </when>
+        <when value="false">
+          <param name="metadata_files" type="hidden" value="NULL" />
+          <param name="cell_id_column" type="hidden" value="NULL" />
+        </when>
+      </conditional>
   </inputs>
 
   <outputs>

--- a/tools/tertiary-analysis/dropletutils/dropletutils-read-10x.xml
+++ b/tools/tertiary-analysis/dropletutils/dropletutils-read-10x.xml
@@ -14,10 +14,8 @@ dropletutils-read-10x-counts.R
     -c TRUE
     -o '${output_rds}'
 
-#if $metadata_files 
+#if $add_metadata_file 
 --metadata-files "${metadata_files}" 
-#end if
-#if $cell_id_column 
 --cell-id-column "${cell_id_column}" 
 #end if
 
@@ -33,10 +31,6 @@ dropletutils-read-10x-counts.R
         <when value="true" >
           <param name="metadata_files" type="data" label="Metadata file" help="Provide metadata file e.g. containing cell types"/>
           <param name="cell_id_column" type="text" label="Cell ID column" help="Cell ID column. Values must match those provided in the expression matrix." />
-        </when>
-        <when value="false">
-          <param name="metadata_files" type="hidden" value="NULL" />
-          <param name="cell_id_column" type="hidden" value="NULL" />
         </when>
       </conditional>
   </inputs>


### PR DESCRIPTION
This PR adds missing parameters from `read-10x-counts.R` so that to allow incorporating metadata file into SCE the produced object. 