### PR TITLE
Seurat version fixing and perplexity exposure

### DIFF
--- a/tools/tertiary-analysis/seurat/seurat_dim_plot.xml
+++ b/tools/tertiary-analysis/seurat/seurat_dim_plot.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_dim_plot" name="Seurat Plot dimension reduction" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_dim_plot" name="Seurat Plot dimension reduction" version="@SEURAT_VERSION@+galaxy0">
     <description>graphs the output of a dimensional reduction technique (PCA by default). Cells are colored by their identity class.</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_export_cellbrowser.xml
+++ b/tools/tertiary-analysis/seurat/seurat_export_cellbrowser.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_export_cellbrowser" name="Seurat Export2CellBrowser" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_export_cellbrowser" name="Seurat Export2CellBrowser" version="@SEURAT_VERSION@+galaxy0">
     <description>produces files for UCSC CellBrowser import.</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_filter_cells.xml
+++ b/tools/tertiary-analysis/seurat/seurat_filter_cells.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_filter_cells" name="Seurat FilterCells" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_filter_cells" name="Seurat FilterCells" version="@SEURAT_VERSION@+galaxy0">
     <description>filter cells in a Seurat object</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_find_clusters.xml
+++ b/tools/tertiary-analysis/seurat/seurat_find_clusters.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_find_clusters" name="Seurat FindClusters" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_find_clusters" name="Seurat FindClusters" version="@SEURAT_VERSION@+galaxy0">
     <description>find clusters of cells</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_find_markers.xml
+++ b/tools/tertiary-analysis/seurat/seurat_find_markers.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_find_markers" name="Seurat FindMarkers" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_find_markers" name="Seurat FindMarkers" version="@SEURAT_VERSION@+galaxy0">
     <description>find markers (differentially expressed genes)</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_find_neighbours.xml
+++ b/tools/tertiary-analysis/seurat/seurat_find_neighbours.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_find_neighbours" name="Seurat FindNeighbours" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_find_neighbours" name="Seurat FindNeighbours" version="@SEURAT_VERSION@+galaxy0">
     <description>constructs a Shared Nearest Neighbor (SNN) Graph</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_find_variable_genes.xml
+++ b/tools/tertiary-analysis/seurat/seurat_find_variable_genes.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_find_variable_genes" name="Seurat FindVariableGenes" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_find_variable_genes" name="Seurat FindVariableGenes" version="@SEURAT_VERSION@+galaxy0">
     <description>identify variable genes</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_macros.xml
+++ b/tools/tertiary-analysis/seurat/seurat_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@VERSION@">0.0.6</token>
+    <token name="@VERSION@">0.0.7</token>
     <token name="@SEURAT_VERSION@">3.1.1</token>
     <xml name="requirements">
         <requirements>
@@ -96,6 +96,8 @@ types of single cell data.
 
     <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
+
+3.1.1_0.0.7: Exposes perplexity and enables tab input.
 
 3.1.1_0.0.6+galaxy0: Moved to Seurat 3.
 

--- a/tools/tertiary-analysis/seurat/seurat_normalise_data.xml
+++ b/tools/tertiary-analysis/seurat/seurat_normalise_data.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_normalise_data" name="Seurat NormaliseData" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_normalise_data" name="Seurat NormaliseData" version="@SEURAT_VERSION@+galaxy0">
     <description>normalise data</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_run_pca.xml
+++ b/tools/tertiary-analysis/seurat/seurat_run_pca.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_run_pca" name="Seurat RunPCA" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_run_pca" name="Seurat RunPCA" version="@SEURAT_VERSION@+galaxy0">
     <description>run a PCA dimensionality reduction</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_run_tsne.xml
+++ b/tools/tertiary-analysis/seurat/seurat_run_tsne.xml
@@ -31,6 +31,9 @@ seurat-run-tsne.R
 #if $adv.random_seed
   --random-seed '$adv.random_seed'
 #end if
+#if $adv.perplexity
+  --perplexity '$adv.perplexity'
+#end if
 
 @OUTPUT_OBJECT@
 --output-embeddings-file output_embed
@@ -51,6 +54,7 @@ seurat-run-tsne.R
               <option value="2" selected="true">2</option>
               <option value="3">3</option>
             </param>
+            <param label="Perplexity" optional="true" name="perplexity" argument="--perplexity" type="integer" help="An integer above 0."/>
             <param label="Random seed" optional="true" name="random_seed" argument="--random-seed" type="integer" help="Seed of the random number generator"/>
         </section>
     </inputs>

--- a/tools/tertiary-analysis/seurat/seurat_run_tsne.xml
+++ b/tools/tertiary-analysis/seurat/seurat_run_tsne.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_run_tsne" name="Seurat RunTSNE" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_run_tsne" name="Seurat RunTSNE" version="@SEURAT_VERSION@+galaxy1">
     <description>run t-SNE dimensionality reduction</description>
     <macros>
         <import>seurat_macros.xml</import>

--- a/tools/tertiary-analysis/seurat/seurat_scale_data.xml
+++ b/tools/tertiary-analysis/seurat/seurat_scale_data.xml
@@ -1,4 +1,4 @@
-<tool id="seurat_scale_data" name="Seurat ScaleData" version="@SEURAT_VERSION@_@VERSION@+galaxy0">
+<tool id="seurat_scale_data" name="Seurat ScaleData" version="@SEURAT_VERSION@+galaxy0">
     <description>scale and center genes</description>
     <macros>
         <import>seurat_macros.xml</import>


### PR DESCRIPTION
This PR:

- Moves to Seurat scripts 0.0.7
- Exposes perplexity in runTSNE
- Fixes version of the tools so that they don't confuse the galaxy sorter.