### PR TITLE
update scmap and scpred wrappers to provide correct output format

### DIFF
--- a/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_scmap_cell" name="Scmap cell projection" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scmap_scmap_cell" name="Scmap cell projection" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>searches each cell in a query dataset for the nearest neighbours by cosine distance within a collection of reference datasets.</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
@@ -34,9 +34,9 @@
     </inputs>
     <outputs>
       <data name="output_single_cell_experiment" format="rdata" />
-      <data name="closest_cells_text_file" format="csv" />
-      <data name="closest_cells_similarities_text_file" format="csv" />
-      <data name="closest_cells_clusters_csv" format="csv">
+      <data name="closest_cells_text_file" format="tsv" />
+      <data name="closest_cells_similarities_text_file" format="tsv" />
+      <data name="closest_cells_clusters_csv" format="tsv">
         <filter>cluster_projection['do_cluster_projection']</filter>
       </data>
     </outputs>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cell.xml
@@ -34,9 +34,9 @@
     </inputs>
     <outputs>
       <data name="output_single_cell_experiment" format="rdata" />
-      <data name="closest_cells_text_file" format="tsv" />
-      <data name="closest_cells_similarities_text_file" format="tsv" />
-      <data name="closest_cells_clusters_csv" format="tsv">
+      <data name="closest_cells_text_file" format="tabular" />
+      <data name="closest_cells_similarities_text_file" format="tabular" />
+      <data name="closest_cells_clusters_csv" format="tabular">
         <filter>cluster_projection['do_cluster_projection']</filter>
       </data>
     </outputs>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
@@ -14,7 +14,7 @@
     </inputs>
     <outputs>
         <data name="output_single_cell_experiment" format="rdata" />
-        <data name="output_txt" format="tsv" />
+        <data name="output_txt" format="tabular" />
     </outputs>
     <tests>
         <test>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
@@ -1,4 +1,4 @@
-<tool id="scmap_scmap_cluster" name="Scmap cluster projection" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scmap_scmap_cluster" name="Scmap cluster projection" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
     <description>projects one dataset to another</description>
     <macros>
         <import>scmap_macros.xml</import>

--- a/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
+++ b/tools/tertiary-analysis/scmap/scmap_scmap_cluster.xml
@@ -14,7 +14,7 @@
     </inputs>
     <outputs>
         <data name="output_single_cell_experiment" format="rdata" />
-        <data name="output_txt" format="csv" />
+        <data name="output_txt" format="tsv" />
     </outputs>
     <tests>
         <test>

--- a/tools/tertiary-analysis/scpred/scpred_eigen_decomp.xml
+++ b/tools/tertiary-analysis/scpred/scpred_eigen_decomp.xml
@@ -1,4 +1,4 @@
-<tool id="scpred_eigen_decompose" name="Scpred eigen-decompose" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="scpred_eigen_decompose" name="Scpred eigen-decompose" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Perform matrix eigen-decomposition; initialize object of scPred class</description>
     <macros>
          <import>scpred_macros.xml</import>

--- a/tools/tertiary-analysis/scpred/scpred_get_feature_space.xml
+++ b/tools/tertiary-analysis/scpred/scpred_get_feature_space.xml
@@ -1,4 +1,4 @@
-<tool id='scpred_get_feature_space' name='ScPred feature space' version='@TOOL_VERSION@+galaxy1' profile="@PROFILE@">
+<tool id='scpred_get_feature_space' name='ScPred feature space' version='@TOOL_VERSION@+galaxy0' profile="@PROFILE@">
     <description>Get feature space for training matrix</description>
     <macros>
          <import>scpred_macros.xml</import>

--- a/tools/tertiary-analysis/scpred/scpred_get_std_output.xml
+++ b/tools/tertiary-analysis/scpred/scpred_get_std_output.xml
@@ -1,4 +1,4 @@
-<tool id="scpred_get_std_output" name="Scpred - get output in standard format" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
+<tool id="scpred_get_std_output" name="Scpred - get output in standard format" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>This method allows to export predicted labels in a standardised format, simplifying downstream analyses.</description>
     <macros>
         <import>scpred_macros.xml</import>

--- a/tools/tertiary-analysis/scpred/scpred_macros.xml
+++ b/tools/tertiary-analysis/scpred/scpred_macros.xml
@@ -4,7 +4,7 @@
     <token name="@PROFILE@">18.01</token>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="0.0.8">scpred-cli</requirement>
+            <requirement type="package" version="0.0.9">scpred-cli</requirement>
                 <yield/>
         </requirements>
     </xml>
@@ -15,6 +15,7 @@
     </xml>
     <token name="@VERSION_HISTORY@"><![CDATA[
         **Version history**
+        1.0.1+galaxy0: Update output format from csv to tsv
         1.0.0+galaxy0: Initilal contribution. Andrey Solovyev, Expression Atlas team https://www.ebi.ac.uk/gxa/home at EMBL-EBI https://www.ebi.ac.uk/.
         ]]></token>
     <xml name="citations">

--- a/tools/tertiary-analysis/scpred/scpred_predict.xml
+++ b/tools/tertiary-analysis/scpred/scpred_predict.xml
@@ -1,4 +1,4 @@
-<tool id="scpred_predict_labels" name="Scpred predict" version="@TOOL_VERSION@+galaxy3">
+<tool id="scpred_predict_labels" name="Scpred predict" version="@TOOL_VERSION@+galaxy0">
     <description>Make cell type predictions using trained model.</description>
      <macros>
         <import>scpred_macros.xml</import>
@@ -29,7 +29,7 @@
     </inputs>
     <outputs>
         <data name="output_tbl_path" format="txt" />
-        <data name="plot_path" format="txt" />
+        <data name="plot_path" format="png" />
         <data name="confusion_table" format="txt" />
     </outputs>
     <tests>

--- a/tools/tertiary-analysis/scpred/scpred_preprocess_data.xml
+++ b/tools/tertiary-analysis/scpred/scpred_preprocess_data.xml
@@ -1,4 +1,4 @@
-<tool id="scpred_preprocess_data" name="Scpred pre-process" version="@TOOL_VERSION@+galaxy3" profile="@PROFILE@">
+<tool id="scpred_preprocess_data" name="Scpred pre-process" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Pre-process input dataset (no train/test split)</description>
     <macros>
         <import>scpred_macros.xml</import>

--- a/tools/tertiary-analysis/scpred/scpred_train_model.xml
+++ b/tools/tertiary-analysis/scpred/scpred_train_model.xml
@@ -1,4 +1,4 @@
-<tool id="scpred_train_model" name="Scpred train" version="@TOOL_VERSION@+galaxy3" profile="@PROFILE@">
+<tool id="scpred_train_model" name="Scpred train" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>Train classification model</description>
     <macros>
         <import>scpred_macros.xml</import>

--- a/tools/tertiary-analysis/scpred/scpred_train_test_split.xml
+++ b/tools/tertiary-analysis/scpred/scpred_train_test_split.xml
@@ -1,4 +1,4 @@
-<tool id="scpred_traint_test_split" name="Scpred train-test split" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
+<tool id="scpred_traint_test_split" name="Scpred train-test split" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
     <description>CPM normalise and partition into train/test data</description>
     <macros>
         <import>scpred_macros.xml</import>


### PR DESCRIPTION
Modify wrappers for scmap and scpred. The changes reflect the updated delimiter in output tables. 