### PR TITLE
Delete test data if large files are present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,17 @@ jobs:
         - |
           if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "develop" ]; then
               # while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_key "$TEST_SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
-              while read -r DIR; do planemo shed_update --shed_target toolshed --shed_key "$SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+              while read -r DIR; do 
+                if [ -d "$DIR/test-data" ]; then
+                    max_test_file_size=$(du test-data/$(ls -S test-data | head -n 1) | awk '{print $1}')
+                    if [ $max_test_file_size -gt 10000 ]; then
+                        echo "Deleting test files, found one > 10Mb" 1>&2
+                        rm -rf $DIR/test-data
+                    fi
+                fi
+
+                planemo shed_update --shed_target toolshed --shed_key "$SHED_KEY" --force_repository_creation "$DIR" || exit 1 
+              done < changed_repositories.list
           fi
 
 env:


### PR DESCRIPTION
We're not allowed to upload files > 10Mb to the shed, so remove test data where such are present prior to shed_update.