### PR TITLE
Bump version for integrate tools to reflect fixed pass-through and tests in last PR

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-integrate-bbknn.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-integrate-bbknn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_integrate_bbknn" name="Scanpy BBKNN" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_integrate_bbknn" name="Scanpy BBKNN" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>batch-balanced K-nearest neighbours</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-integrate-combat.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-integrate-combat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_integrate_combat" name="Scanpy ComBat" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_integrate_combat" name="Scanpy ComBat" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>adjust expression for variables that might introduce batch effect</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-integrate-harmony.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-integrate-harmony.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_integrate_harmony" name="Scanpy Harmony" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_integrate_harmony" name="Scanpy Harmony" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>adjust principal components for variables that might introduce batch effect</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-integrate-mnn.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-integrate-mnn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_integrate_mnn" name="Scanpy MNN" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_integrate_mnn" name="Scanpy MNN" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>correct batch effects by matching mutual nearest neighbors</description>
   <macros>
     <import>scanpy_macros2.xml</import>


### PR DESCRIPTION
https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/pull/191 should have included a wrapper version bump. 

At the time that was merged the CI was broken and the fix https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/commit/f820980fbece5283a44cc2abad65561e0d1267e6 could not trigger the shed update since the commits did not include and relevant repo changes. 

So this PR adds those version bumps and serves to trigger shed_update for the integrate tools.