### PR TITLE
Bump anndata ops for new scanpy

### DIFF
--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -213,6 +213,13 @@ Performs the following operations:
   * Unstructure annotations, like gene markers.
 
 This functionality will probably be added in the future to a larger package.
+
+History
+-------
+
+0.0.4+galaxy0: Moves to Scanpy Scripts 0.3.0 (Scanpy 1.6.0)
+
+0.0.3+galaxy0: Adds ability to merge AnnData objects (Scanpy 1.4.3).
 ]]></help>
   <expand macro="citations"/>
 </tool>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="anndata_ops" name="AnnData Operations" version="0.0.3+galaxy1" profile="@PROFILE@">
+<tool id="anndata_ops" name="AnnData Operations" version="0.0.4+galaxy0" profile="@PROFILE@">
   <description>modifies metadata and flags genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="anndata_ops" name="AnnData Operations" version="0.0.4+galaxy0" profile="@PROFILE@">
+<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
   <description>modifies metadata and flags genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -217,7 +217,7 @@ This functionality will probably be added in the future to a larger package.
 History
 -------
 
-0.0.4+galaxy0: Moves to Scanpy Scripts 0.3.0 (Scanpy 1.6.0)
+1.6.0+galaxy0: Moves to Scanpy Scripts 0.3.0 (Scanpy 1.6.0), versioning switched to track Scanpy as other tools.
 
 0.0.3+galaxy0: Adds ability to merge AnnData objects (Scanpy 1.4.3).
 ]]></help>


### PR DESCRIPTION
Our currently installed version of this is failing due to outdated scanpy/ anndata. Unfortunately I didn't bump the version on this tool when I updated scanpy_macros2.xml, and without a new version our automated tool install processes are not pulling the latest commit from the shed. There will also now be multiple iterations of this tool in the shed with the same version but different Scanpy dependencies. 

This should create a new version of the tool and allow our automated tool loading process to pull a version with the newest Scanpy used by the other Scanpy versions. 