### PR TITLE
Feature/named slots

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
@@ -10,7 +10,7 @@
 #if $settings.resolution_file
     #set resolution = Path($settings.resolution_file.__str__).read_text().strip()
 #elif $settings.resolution
-    #set resolution = $settings.resolution.strip()
+    #set resolution = $settings.resolution.__str__.strip()
 #end if
 
 ln -s '${input_obj_file}' input.h5 &&

--- a/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
@@ -66,7 +66,7 @@ PYTHONIOENCODING=utf-8 scanpy-find-cluster
         <param name="layer" argument="--layer" value="" type="text"
             label="Key from adata.layers whose value will be used to perform tests on. (Default: use .X)"/>
         <param name="key_added" argument="--key-added" type="text" optional="true"
-            label="Additional suffix to the name of the slot to save the calculated clustering. METHOD will be subsituted with the value of the method setting, RESOLUTION with the value of that field."/>
+            label="Additional suffix to the name of the slot to save the calculated clustering" help="If included, the keyword 'METHOD' will be substituted with the value of the method setting and 'RESOLUTION' with the value of that field."/>
         <param name="resolution" argument="--resolution" type="float" min="0.0" value="1.0"
                label="Resolution, high value for more and smaller clusters"/>
         <param name="resolution_file" argument="--resolution" type="data" format="txt,tsv" optional="true"

--- a/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
@@ -1,26 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_cluster" name="Scanpy FindCluster" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_find_cluster" name="Scanpy FindCluster" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>based on community detection on KNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
+#from pathlib import Path
+#if $settings.resolution_file
+    #set resolution = Path($settings.resolution_file.__str__).read_text().strip()
+#elif $settings.resolution
+    #set resolution = $settings.resolution.strip()
+#end if
+
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-find-cluster
     ${method}
 #if $settings.default == "false"
     --neighbors-key '${settings.neighbors_key}'
+    #if $settings.key_added
+        #set key_added = $settings.key_added.replace('METHOD', $method.__str__)
+        #if $resolution
+            #set key_added = $key_added.replace('RESOLUTION', $resolution.__str__)
+        #end if
+        --key-added '${key_added}'
+    #end if
+    #if $resolution
+        --resolution '$resolution'
+    #end if
     #if $settings.layer
         --layer '${settings.layer}'
-    #end if
-    #if $settings.key_added
-        --key-added '${settings.key_added}'
-    #end if
-    #if $settings.resolution_file
-        --resolution \$( cat $settings.resolution_file )
-    #elif $settings.resolution
-        --resolution '${settings.resolution}'
     #end if
     #if $settings.restrict_to
         --restrict-to '${settings.restrict_to}'
@@ -57,8 +66,7 @@ PYTHONIOENCODING=utf-8 scanpy-find-cluster
         <param name="layer" argument="--layer" value="" type="text"
             label="Key from adata.layers whose value will be used to perform tests on. (Default: use .X)"/>
         <param name="key_added" argument="--key-added" type="text" optional="true"
-            label="Additional suffix to the name of the slot to save the calculated clustering"/>
-
+            label="Additional suffix to the name of the slot to save the calculated clustering. METHOD will be subsituted with the value of the method setting, RESOLUTION with the value of that field."/>
         <param name="resolution" argument="--resolution" type="float" min="0.0" value="1.0"
                label="Resolution, high value for more and smaller clusters"/>
         <param name="resolution_file" argument="--resolution" type="data" format="txt,tsv" optional="true"

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>to derive kNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -6,14 +6,27 @@
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
+#from pathlib import Path
+#if $settings.n_neighbors_file
+    #set n_neighbors = Path($settings.n_neighbors_file.__str__).read_text().strip()
+#elif $settings.n_neighbors
+    #set n_neighbors = $settings.n_neighbors.__str__.strip()
+#end if
+
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-neighbors
 #if $settings.default == "false"
-    #if $settings.n_neighbors_file
-        --n-neighbors \$( cat $settings.n_neighbors_file )
-    #elif $settings.n_neighbors
-        --n-neighbors '${settings.n_neighbors}'
+    #if $n_neighbors
+        --n-neighbors $n_neighbors
     #end if
+    #if $settings.key_added
+        #set key_added = $settings.key_added
+        #if $n_neighbors
+            #set key_added = $key_added.replace('N_NEIGHBORS', $n_neighbors.__str__)
+        #end if
+        --key-added '${key_added}'
+    #end if
+
     --method '${settings.method}'
     --metric '${settings.metric}'
     --random-state '${settings.random_seed}'
@@ -36,6 +49,8 @@ PYTHONIOENCODING=utf-8 scanpy-neighbors
       <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
       <when value="true"/>
       <when value="false">
+        <param name="key_added" argument="--key-added" type="text" optional="true" label="Key added"
+            help="If not specified, the neighbors data is stored in .uns[‘neighbors’], distances and connectivities are stored in .obsp[‘distances’] and .obsp[‘connectivities’] respectively. If specified, the neighbors data is added to .uns[key_added], distances are stored in .obsp[key_added+’_distances’] and connectivities in .obsp[key_added+’_connectivities’]." value='neighbours' />
         <param name="n_neighbors" argument="--n-neighbors" type="integer" value="15" label="Maximum number of neighbors used"/>
         <param name="n_neighbors_file" argument="--n-neighbors" type="data" format="txt,tsv" optional="true"
                label="File with n_neighbours, use with parameter iterator. Overrides the n_neighbors setting"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -73,7 +73,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
       <when value="true"/>
       <when value="false">
         <param name="key_added" argument="--key-added" type="text" optional="true"
-               label="Additional suffix to the name of the slot to save the embedding. PERPLEXITY will be subsituted with the value of the perplexity setting."/>
+               label="Additional suffix to the name of the slot to save the embedding" help="If included, PERPLEXITY will be substituted with the value of the perplexity setting."/>
         <param name="perplexity" argument="--perplexity" type="float" value="30" label="The perplexity is related to the number of nearest neighbours, select a value between 5 and 50"/>
         <param name="perplexity_file" argument="--perplexity" type="data" format="txt,tsv" label="The perplexity is related to the number of nearest neighbours" help="For use with the parameter iterator. Overrides the persplexity option above" optional="true"/>
         <param name="early_exaggeration" argument="--early-exaggeration" type="float" value="12" label="Controls the tightness within and between clusters"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -1,27 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>visualise cell clusters using tSNE</description>
   <macros>
     <import>scanpy_macros2.xml</import>
   </macros>
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
+#from pathlib import Path
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-run-tsne
 #if $use_rep != "auto"
     --use-rep '${use_rep}'
-#end if
-#if $key_added
-    --key-added '${key_added}'
 #end if
 #if $embeddings
     --export-embedding embeddings.tsv
 #end if
 #if $settings.default == "false"
     #if $settings.perplexity_file
-        --perplexity \$( cat $settings.perplexity_file )
-    #else
-        --perplexity '${settings.perplexity}'
+        #set perplexity = Path($settings.perplexity_file.__str__).read_text().strip()
+    #elif $settings.perplexity
+        #set perplexity = $settings.perplexity.__str__.strip()
+    #end if      
+    #if $perplexity
+        --perplexity '$perplexity'
+    #end if
+    #if $settings.key_added
+        #set key_added = $settings.key_added
+        #if $perplexity
+            #set key_added = $key_added.replace('PERPLEXITY', $perplexity.__str__)
+        #end if
+        --key-added '${key_added}'
     #end if
     --early-exaggeration '${settings.early_exaggeration}'
     --learning-rate '${settings.learning_rate}'
@@ -53,13 +61,12 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
       <option value="X">X, use normalised expression values</option>
       <option value="auto" selected="true">Automatically chosen based on problem size</option>
     </param>
-    <param name="key_added" argument="--key-added" type="text" optional="true"
-           label="Additional suffix to the name of the slot to save the embedding"/>
-
     <conditional name="settings">
       <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
       <when value="true"/>
       <when value="false">
+        <param name="key_added" argument="--key-added" type="text" optional="true"
+               label="Additional suffix to the name of the slot to save the embedding. PERPLEXITY will be subsituted with the value of the perplexity setting."/>
         <param name="perplexity" argument="--perplexity" type="float" value="30" label="The perplexity is related to the number of nearest neighbours, select a value between 5 and 50"/>
         <param name="perplexity_file" argument="--perplexity" type="data" format="txt,tsv" label="The perplexity is related to the number of nearest neighbours" help="For use with the parameter iterator. Overrides the persplexity option above" optional="true"/>
         <param name="early_exaggeration" argument="--early-exaggeration" type="float" value="12" label="Controls the tightness within and between clusters"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -7,6 +7,7 @@
   <expand macro="requirements"/>
   <command detect_errors="exit_code"><![CDATA[
 #from pathlib import Path
+#set embeddings_tsv='embeddings.tsv'
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-run-tsne
 #if $use_rep != "auto"
@@ -49,8 +50,10 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
 #end if
     @INPUT_OPTS@
     @OUTPUT_OPTS@
-#if $embeddings_tsv
-    && mv '${embeddings_tsv}' embeddings.tsv
+#if $embeddings
+    #if $embeddings_tsv != 'embeddings.tsv'
+        && mv '${embeddings_tsv}' embeddings.tsv
+    #end if
 #end if
 
 ]]></command>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -30,6 +30,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
             #set key_added = $key_added.replace('PERPLEXITY', $perplexity.__str__)
         #end if
         --key-added '${key_added}'
+        #set embeddings_tsv="embeddings_" + $key_added.__str__ + ".tsv"    
     #end if
     --early-exaggeration '${settings.early_exaggeration}'
     --learning-rate '${settings.learning_rate}'
@@ -48,6 +49,9 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
 #end if
     @INPUT_OPTS@
     @OUTPUT_OPTS@
+#if $embeddings_tsv
+    && mv '${embeddings_tsv}' embeddings.tsv
+#end if
 
 ]]></command>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_umap" name="Scanpy RunUMAP" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_run_umap" name="Scanpy RunUMAP" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>visualise cell clusters using UMAP</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -8,10 +8,11 @@
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-run-umap
-    --neighbors-key '${use_graph}'
+#set neighbors_key = $use_graph.replace('INPUT_OBJ', $input_obj_file.__getattr__('name'))
+--neighbors-key '${neighbors_key}'
 #if $key_added
-    #if $use_graph
-        #set key_added = $key_added.replace('NEIGHBORS_KEY', $use_graph.__str__)
+    #if $neighbors_key
+        #set key_added = $key_added.replace('NEIGHBORS_KEY', $neighbors_key.__str__)
     #set embeddings_tsv="embeddings_" + $key_added.__str__ + ".tsv"    
 #end if
     --key-added '${key_added}'

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -9,6 +9,7 @@
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-run-umap
 #set neighbors_key = $use_graph.replace('INPUT_OBJ', $input_obj_file.__getattr__('name'))
+#set embeddings_tsv='embeddings.tsv'
 --neighbors-key '${neighbors_key}'
 #if $key_added
     #if $neighbors_key
@@ -37,8 +38,10 @@ PYTHONIOENCODING=utf-8 scanpy-run-umap
 #end if
     @INPUT_OPTS@
     @OUTPUT_OPTS@
-#if $embeddings_tsv
-    && mv '${embeddings_tsv}' embeddings.tsv
+#if $embeddings
+    #if $embeddings_tsv != 'embeddings.tsv'
+        && mv '${embeddings_tsv}' embeddings.tsv
+    #end if
 #end if
 
 ]]></command>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -9,7 +9,13 @@
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-run-umap
     --neighbors-key '${use_graph}'
+#if $key_added
+    #if $use_graph
+        #set key_added = $key_added.replace('NEIGHBORS_KEY', $use_graph.__str__)
+    #set embeddings_tsv="embeddings_" + $key_added.__str__ + ".tsv"    
+#end if
     --key-added '${key_added}'
+#end if
 #if $embeddings
     --export-embedding embeddings.tsv
 #end if
@@ -30,6 +36,9 @@ PYTHONIOENCODING=utf-8 scanpy-run-umap
 #end if
     @INPUT_OPTS@
     @OUTPUT_OPTS@
+#if $embeddings_tsv
+    && mv '${embeddings_tsv}' embeddings.tsv
+#end if
 
 ]]></command>
 


### PR DESCRIPTION
This PR adds some rudimentary placeholder handling to the key_added slots of various tools, so that we can have results for important parameters keyed by those parameters. Ideally I'd have like to use the wildcard functionality available when configuring a workflow and renaming outputs (e.g. 'umap_#{input_obj_file}.tsv'), but that didn't work when I tried. 

The UMAP solution is particularly clunky, since I'm having to use the output file name of the neighbors step (we already do this for naming the umap outputs). 

I've also added a fix to the situation whereby embeddings for umap and tsne are not exported to the expected location by the CLI layer were key_added is specified. 

This is clearly a hack, in expectation of a comprehensive solution in future whereby e.g. UMAP parameters are stored somewhere (e.g. in .uns) and related to specified sets of umap embeddings. That's a bigger project involving developments at the CLI layer and/or a conversation with the developers of Scanpy itself. 