### PR TITLE
Make parameter iterator generic

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-parameter-iterator.xml
@@ -1,4 +1,4 @@
-<tool id="scanpy_parameter_iterator" name="Scanpy ParameterIterator" version="0.0.1+galaxy2">
+<tool id="scanpy_parameter_iterator" name="Scanpy ParameterIterator" version="0.0.1+galaxy3">
     <description>produce an iteration over a defined parameter</description>
     <macros>
       <import>scanpy_macros.xml</import>
@@ -20,11 +20,7 @@
 	    ]]></command>
 
     <inputs>
-      <param type="select" name="parameter_name" label="Parameter name" help="Select a type of parameter">
-        <option value="perplexity" selected="True">Perplexity</option>
-        <option value="resolution">Resolution</option>
-        <option value="n_neighbors">Number of neighbors</option>
-      </param> 
+      <param type="text" name="parameter_name" value='perplexity' label="Parameter type" help="This is a value that will be prefixed to output file names" />
       <conditional name="input_type">    
         <param type="select" name="parameter_values" label="Choose the format of the input values" help="step increase values or list of all the parameter values">
           <option value="list_comma_separated_values" selected="True">List of all parameter values to be iterated</option>


### PR DESCRIPTION
# Description

This PR renders the parameter iterator more useful by making parameter type a free text field rather than a selector. There is nothing magic about the values in the selector, and I think this tool could be useful to us in a wider range of contexts (including a current one related to iterating over metadata variables). 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
