### PR TITLE
Bump scanpy-scripts for rank_genes_groups fix

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -49,7 +49,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.3.0">scanpy-scripts</requirement>
+      <requirement type="package" version="0.3.1">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
# Description

Just a tiny bump to incorporate https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/88, and prevent things dying at marker detection when we have singlet clusters.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
