### PR TITLE
Update plot trajectory - adding legend toggle

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_plot_trajectory" name="Scanpy PlotTrajectory" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_plot_trajectory" name="Scanpy PlotTrajectory" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>visualise cell trajectories</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -12,6 +12,8 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
     --use-key '${use_key}'
 #end if
     --layout ${layout}
+#end
+    --layout-loc ${layout-loc}
 #if $basis
     --basis ${basis}
 #end if

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -12,7 +12,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
     --use-key '${use_key}'
 #end if
     --layout ${layout}
-    --legend-loc ${legend_loc}
+    --legend-loc '${legend_loc}'
 #if $basis
     --basis ${basis}
 #end if

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -12,7 +12,6 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
     --use-key '${use_key}'
 #end if
     --layout ${layout}
-#end
     --layout-loc ${layout-loc}
 #if $basis
     --basis ${basis}

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -49,6 +49,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
       <option value="fa">ForceAtlas2</option>
       <option value="fr" selected="true">Fruchterman-Reingold</option>
       <option value="rt">Reingold-Tilford</option>
+    </param>
     <param name="legend_loc" argument="--legend-loc" type="select" label="Location of legend">
       <option value="right margin" selected="true">Right margin</option>
       <option value="on data">On data</option>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -49,6 +49,9 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
       <option value="fa">ForceAtlas2</option>
       <option value="fr" selected="true">Fruchterman-Reingold</option>
       <option value="rt">Reingold-Tilford</option>
+    <param name="legend_loc" argument="--legend-loc" type="select" label="Location of legend">
+      <option value="right margin" selected="true">Right margin</option>
+      <option value="on data">On data</option>
     </param>
     <param name="basis" argument="--basis" type="text" optional="true" label="Name of the embedding to plot"
            help="Must be a key of `.obsm` without the prefix 'X_', e.g. 'umap'."/>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -12,7 +12,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli plot paga
     --use-key '${use_key}'
 #end if
     --layout ${layout}
-    --layout-loc ${layout-loc}
+    --legend-loc ${legend_loc}
 #if $basis
     --basis ${basis}
 #end if


### PR DESCRIPTION
I'm hoping this will give a legend-location option for the tool. Trajectories are best visualised with the node/number etc. on the chart rather than next to it.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
