### PR TITLE
Allow non-specification of n_pcs for PCA

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_pca" name="Scanpy RunPCA" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_run_pca" name="Scanpy RunPCA" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>for dimensionality reduction</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -8,7 +8,9 @@
   <command detect_errors="exit_code"><![CDATA[
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-run-pca
+#if $n_pcs
     --n-comps '${n_pcs}'
+#end if    
 #if $run_mode.chunked
     --chunked
     --chunk-size '${run_mode.chunk_size}'
@@ -31,7 +33,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-pca
   <inputs>
     <expand macro="input_object_params"/>
     <expand macro="output_object_params"/>
-    <param name="n_pcs" argument="--n-comps" type="integer" min="2" value="50" label="Number of PCs to produce"/>
+    <param name="n_pcs" argument="--n-comps" type="integer" optional="true" min="2" value="" label="Number of PCs to produce"/>
     <conditional name="run_mode">
       <param name="chunked" argument="--chunked" type="boolean" checked="false" label="Perform incremental PCA by chunks"/>
       <when value="true">

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -49,7 +49,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.3.1">scanpy-scripts</requirement>
+      <requirement type="package" version="0.3.2">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
# Description

This is the Galaxy component of https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/91, providing the ability to not specify a number of principal components to PCA in Scanpy, and allow Scanpy to fall back when the number of obs/var is too small for the default 50 components (which is what we were specifying anyway).

I've checked this locally with a previously failing object using Planemo and it works fine. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
