### PR TITLE
Fix cheetah pts not found for marker genes when running with default parameters

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -298,7 +298,7 @@ jobs:
     - name: Install Planemo
       run: pip install planemo
     - name: Install jq
-      run: sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq jq
+      run: sudo apt-get install -yq jq
     - name: Combine outputs
       run: find artifacts/ -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
     - name: Create tool_test_output.html

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -298,7 +298,7 @@ jobs:
     - name: Install Planemo
       run: pip install planemo
     - name: Install jq
-      run: sudo apt-get install jq
+      run: sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq jq
     - name: Combine outputs
       run: find artifacts/ -name tool_test_output.json -exec sh -c 'planemo merge_test_reports "$@" tool_test_output.json' sh {} +
     - name: Create tool_test_output.html

--- a/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
@@ -33,8 +33,8 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
     #end if
     --reference '${settings.reference}'
     --filter-params 'min_in_group_fraction:${settings.min_in_group_fraction},max_out_group_fraction:${settings.max_out_group_fraction},min_fold_change:${settings.min_fold_change}'
-    #end if
     $settings.pts $settings.tie_correct
+    #end if
     @INPUT_OPTS@
     @OUTPUT_OPTS@
 ]]></command>


### PR DESCRIPTION
# Description

This PR Fixes #219 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  

I haven't bumped the +galaxy number to see if in newer versions of Galaxy the new revision replaces the defective revision with the same +galaxy number (we know that this doesn't happen in 19.05, but our newer setups should see it).
