### PR TITLE
Remove improper paga in init-pos default

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-run-fdg.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-fdg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_fdg" name="Scanpy RunFDG" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_run_fdg" name="Scanpy RunFDG" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>visualise cell clusters using force-directed graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -47,9 +47,7 @@ PYTHONIOENCODING=utf-8 scanpy-cli embed fdg
         <param name="neighbors_key" argument="--neighbors-key" value="neighbors" type="text"
                label="Name of the slot that holds the KNN graph"/>
         <param name="obsp" type="boolean" checked="false" label="Use .obsp[obsp] as adjacency" help="You can’t specify both obsp and neighbors-key at the same time."/>
-        <param name="init_pos" argument="--init-pos" type="text" label="Method to initialise embedding, any key for adata.obsm or choose from the preset methods">
-          <option value="paga">paga</option>
-        </param>
+        <param name="init_pos" argument="--init-pos" type="text" label="Method to initialise embedding, any key for adata.obsm or choose from the preset methods"/>
         <param name="layout" argument="--layout" type="select" label="Graph layout">
           <option value="fa">fa</option>
           <option value="fr" selected="true">fr</option>


### PR DESCRIPTION
# Description

As reported by @nomadscientist , this tool was passing 'paga' as init-pos regardless of the setting. This is now breaking due to something in the way the paga results are stored (I think), which needs investigating, but we can at least fix the option.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
