### PR TITLE
Adding diff_map option

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>to derive kNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -58,6 +58,7 @@ PYTHONIOENCODING=utf-8 scanpy-neighbors
         <param name="use_rep" type="select" label="Use the indicated representation">
           <option value="X_pca" selected="true">X_pca, use PCs</option>
           <option value="X">X, use normalised expression values</option>
+          <option value="X_diffmap"> X_diffmap, use diffusion map</option>
         </param>
         <param name="n_pcs" argument="--n-pcs" type="integer" value="50" optional="true" label="Number of PCs to use"/>
         <param name="knn" argument="--knn" type="boolean" truevalue="" falsevalue="--no-knn" checked="true"


### PR DESCRIPTION
# Description

I added an option for X_diffmap in ComputeGraph

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
