### PR TITLE
Enables var field modification in AnnData Ops

### DIFF
--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -331,7 +331,7 @@ adata.write('output.h5', compression='gzip')
         <param name="default" value="true"/>
         <param name="r_source" value="read_10x.h5"/>
       </conditional>
-      <output name="output_h5ad" ftype="h5ad">
+      <output name="output_h5ad" file="anndata_ops_raw.h5" ftype="h5ad" compare="sim_size">
         <assert_contents>
           <has_h5_keys keys="raw/X" />
 	</assert_contents>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -65,13 +65,13 @@ adata.obs['${s.to_obs}'] = adata.obs['${s.from_obs}']
 del adata.obs['${s.from_obs}']
 #end if
 #end for
-	    
+
 #for $i, $s in enumerate($var_modifications)
 adata.var['${s.to_var}'] = adata.var['${s.from_var}']
 #if not $s.keep_original:
 del adata.var['${s.from_var}']
 #end if
-#end for	    
+#end for
 
 gene_names = getattr(adata.var, gene_name)
 
@@ -99,7 +99,7 @@ del ad_s
 ad_s = sc.read('x_source_${i}.h5')
 if adata.n_obs == ad_s.n_obs and all(adata.obs_names == ad_s.obs_names):
   #set xs=$copy_x.xlayers[$i]
-  if "${xs.dest}" == '': 
+  if "${xs.dest}" == '':
     logging.error("%sth destination layer for %sth X source not specified" % ("${i}", "${i}"))
     sys.exit(1)
   adata.layers["${xs.dest}"] = ad_s.X
@@ -119,8 +119,8 @@ if adata.n_obs == ad_s.n_obs and all(adata.obs_names == ad_s.obs_names):
   for l_to_copy in layers_to_copy:
     suffix=''
     if l_to_copy in adata.layers:
-        suffix = "_${i}" 
-    
+        suffix = "_${i}"
+
     adata.layers[l_to_copy+suffix] = ad_s.layers[l_to_copy]
   #end for
 else:
@@ -139,8 +139,8 @@ if adata.n_obs == ad_s.n_obs and all(adata.obs_names == ad_s.obs_names):
   for k_to_copy in keys_to_copy:
     suffix=''
     if k_to_copy in adata.obs:
-        suffix = "_${i}" 
-    
+        suffix = "_${i}"
+
     adata.obs[[k_to_copy+suffix]] = ad_s.obs[[k_to_copy]]
     if k_to_copy in ad_s.uns.keys():
       adata.uns[k_to_copy+suffix] = ad_s.uns[k_to_copy]
@@ -314,6 +314,13 @@ adata.write('output.h5', compression='gzip')
       <param name="color_by" value="louvain"/>
       <output name="output_h5ad" file="anndata_ops.h5" ftype="h5ad" compare="sim_size"/>
     </test>
+    <test>
+      <param name="input_obj_file" value="anndata_ops.h5"/>
+    <param name="from_var" value = "gene_symbols" />
+    <param name="to_var" value = "hello_all" />
+    <param name="keep_original" />
+    <output name = "output_h5ad" file="anndata_ops_hello.h5" ftype="h5ad"  />
+  </test>
     <test>
       <param name="input_obj_file" value="find_cluster.h5"/>
       <param name="input_format" value="anndata"/>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -316,13 +316,13 @@ adata.write('output.h5', compression='gzip')
     </test>
     <test>
       <param name="input_obj_file" value="anndata_ops.h5"/>
-    <param name="from_var" value = "gene_symbols" />
-    <param name="to_var" value = "hello_all" />
-    <output name="output_h5ad" ftype="h5ad">
-    <assert_contents>
-      <has_h5_keys keys="hello_all" />
-  </assert_contents>
-    </output>
+      <param name="from_var" value = "gene_symbols" />
+      <param name="to_var" value = "hello_all" />
+      <output name="output_h5ad" ftype="h5ad">
+        <assert_contents>
+          <has_h5_keys keys="var/hello_all" />
+        </assert_contents>
+      </output>
     </test>
     <test>
       <param name="input_obj_file" value="find_cluster.h5"/>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -318,9 +318,12 @@ adata.write('output.h5', compression='gzip')
       <param name="input_obj_file" value="anndata_ops.h5"/>
     <param name="from_var" value = "gene_symbols" />
     <param name="to_var" value = "hello_all" />
-    <param name="keep_original" />
-    <output name = "output_h5ad" file="anndata_ops_hello.h5" ftype="h5ad"  />
-  </test>
+    <output name="output_h5ad" ftype="h5ad">
+    <assert_contents>
+      <has_h5_keys keys="hello_all" />
+  </assert_contents>
+    </output>
+    </test>
     <test>
       <param name="input_obj_file" value="find_cluster.h5"/>
       <param name="input_format" value="anndata"/>
@@ -328,7 +331,7 @@ adata.write('output.h5', compression='gzip')
         <param name="default" value="true"/>
         <param name="r_source" value="read_10x.h5"/>
       </conditional>
-      <output name="output_h5ad" file="anndata_ops_raw.h5" ftype="h5ad" compare="sim_size">
+      <output name="output_h5ad" ftype="h5ad">
         <assert_contents>
           <has_h5_keys keys="raw/X" />
 	</assert_contents>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>modifies metadata and flags genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -65,6 +65,13 @@ adata.obs['${s.to_obs}'] = adata.obs['${s.from_obs}']
 del adata.obs['${s.from_obs}']
 #end if
 #end for
+	    
+#for $i, $s in enumerate($var_modifications)
+adata.var['${s.to_var}'] = adata.var['${s.from_var}']
+#if not $s.keep_original:
+del adata.var['${s.from_var}']
+#end if
+#end for	    
 
 gene_names = getattr(adata.var, gene_name)
 
@@ -220,6 +227,15 @@ adata.write('output.h5', compression='gzip')
       <param name="to_obs" type="text" label="New name" help="New name in observations that you want to change"/>
       <param name="keep_original" type="boolean" label="Keep original" help="If activated, it will also keep the original column" checked="false"/>
     </repeat>
+    <repeat name="var_modifications" title="Change field names in AnnData var" min="0">
+      <param name="from_var" type="text" label="Original name" help="Name in var that you want to change">
+        <sanitizer>
+          <valid initial="string.printable"/>
+        </sanitizer>
+      </param>
+      <param name="to_var" type="text" label="New name" help="New name in var that you want to change"/>
+      <param name="keep_original" type="boolean" label="Keep original" help="If activated, it will also keep the original column" checked="false"/>
+    </repeat>
     <param name="gene_symbols_field" value='index' type="text" label="Gene symbols field in AnnData" help="Field inside var.params where the gene symbols are, normally 'index' or 'gene_symbols'"/>
     <repeat name="gene_flags" title="Flag genes that start with these names">
       <param name="startswith" type="text" label="Starts with" help="Text that you expect the genes to be flagged to start with, such as 'MT-' for mito genes"/>
@@ -352,7 +368,7 @@ Operations on AnnData objects
 
 Performs the following operations:
 
-* Change observation fields, mostly for downstreaming processes convenience. Multiple fields can be changed as one.
+* Change observation/var fields, mostly for downstreaming processes convenience. Multiple fields can be changed as one.
 * Flag genes that start with a certain text: useful for flagging mitochondrial, spikes or other groups of genes.
 * For the flags created, calculates qc metrics (pct_<flag>_counts).
 * Calculates `n_genes`, `n_counts` for cells and `n_cells`, `n_counts` for genes.


### PR DESCRIPTION
# Description

Enables changes in var field names, as it is currently possible with obs fields in AnnData Ops tool.

Fixes #221.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
