### PR TITLE
Representation-consuming steps to text field

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>to derive kNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -31,7 +31,7 @@ PYTHONIOENCODING=utf-8 scanpy-neighbors
     --method '${settings.method}'
     --metric '${settings.metric}'
     --random-state '${settings.random_seed}'
-    #if $settings.use_rep != "auto"
+    #if $settings.use_rep
         --use-rep '${settings.use_rep}'
     #end if
     #if $settings.n_pcs
@@ -55,11 +55,7 @@ PYTHONIOENCODING=utf-8 scanpy-neighbors
         <param name="n_neighbors" argument="--n-neighbors" type="integer" value="15" label="Maximum number of neighbors used"/>
         <param name="n_neighbors_file" argument="--n-neighbors" type="data" format="txt,tsv" optional="true"
                label="File with n_neighbours, use with parameter iterator. Overrides the n_neighbors setting"/>
-        <param name="use_rep" type="select" label="Use the indicated representation">
-          <option value="X_pca" selected="true">X_pca, use PCs</option>
-          <option value="X">X, use normalised expression values</option>
-          <option value="X_diffmap"> X_diffmap, use diffusion map</option>
-        </param>
+        <param name="use_rep" argument="--use-rep" type="text" optional="true" label="Use the indicated representation" help="'X' (for the content of .X, usually normalised expression values) or any key for .obsm (e.g. X_pca for PCA) is valid. If not set, the representation is chosen automatically: For .n_vars < 50, .X is used, otherwise ‘X_pca’ is used. If ‘X_pca’ is not present, it’s computed with default parameters."/>
         <param name="n_pcs" argument="--n-pcs" type="integer" value="50" optional="true" label="Number of PCs to use"/>
         <param name="knn" argument="--knn" type="boolean" truevalue="" falsevalue="--no-knn" checked="true"
                label="Use hard threshold to restrict neighbourhood size (otherwise use a Gaussian kernel to down weight distant neighbors)"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -55,7 +55,7 @@ PYTHONIOENCODING=utf-8 scanpy-neighbors
         <param name="n_neighbors" argument="--n-neighbors" type="integer" value="15" label="Maximum number of neighbors used"/>
         <param name="n_neighbors_file" argument="--n-neighbors" type="data" format="txt,tsv" optional="true"
                label="File with n_neighbours, use with parameter iterator. Overrides the n_neighbors setting"/>
-        <param name="use_rep" argument="--use-rep" type="text" optional="true" label="Use the indicated representation" help="'X' (for the content of .X, usually normalised expression values) or any key for .obsm (e.g. X_pca for PCA) is valid. If not set, the representation is chosen automatically: For .n_vars < 50, .X is used, otherwise ‘X_pca’ is used. If ‘X_pca’ is not present, it’s computed with default parameters."/>
+        <param name="use_rep" argument="--use-rep" type="text" optional="true" label="Use the indicated representation" help="'X' (for the content of .X, usually normalised expression values) or any key for .obsm (e.g. X_pca for PCA) is valid. If not set, the representation is chosen automatically: For .n_vars less than 50, .X is used, otherwise ‘X_pca’ is used. If ‘X_pca’ is not present, it’s computed with default parameters."/>
         <param name="n_pcs" argument="--n-pcs" type="integer" value="50" optional="true" label="Number of PCs to use"/>
         <param name="knn" argument="--knn" type="boolean" truevalue="" falsevalue="--no-knn" checked="true"
                label="Use hard threshold to restrict neighbourhood size (otherwise use a Gaussian kernel to down weight distant neighbors)"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>visualise cell clusters using tSNE</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -9,7 +9,7 @@
 #set embeddings_tsv='embeddings.tsv'
 ln -s '${input_obj_file}' input.h5 &&
 PYTHONIOENCODING=utf-8 scanpy-run-tsne
-#if $use_rep != "auto"
+#if $use_rep
     --use-rep '${use_rep}'
 #end if
 #if $embeddings
@@ -64,11 +64,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
     <expand macro="output_object_params"/>
     <param name="embeddings" type="boolean" checked="true" label="Output embeddings in tsv format"/>
 
-    <param name="use_rep" argument="--use-rep" type="select" label="Use the indicated representation">
-      <option value="X_pca">X_pca, use PCs</option>
-      <option value="X">X, use normalised expression values</option>
-      <option value="auto" selected="true">Automatically chosen based on problem size</option>
-    </param>
+    <param name="use_rep" argument="--use-rep" type="text" optional="true" label="Use the indicated representation" help="Use the indicated representation. 'X' (for the content of .X, usuaally normalised expression values) or any key for .obsm (e.g. X_pca for PCA) is valid. If not set, the representation is chosen automatically: For .n_vars < 50, .X is used, otherwise ‘X_pca’ is used. If ‘X_pca’ is not present, it’s computed with default parameters."/>
     <conditional name="settings">
       <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
       <when value="true"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -64,7 +64,7 @@ PYTHONIOENCODING=utf-8 scanpy-run-tsne
     <expand macro="output_object_params"/>
     <param name="embeddings" type="boolean" checked="true" label="Output embeddings in tsv format"/>
 
-    <param name="use_rep" argument="--use-rep" type="text" optional="true" label="Use the indicated representation" help="Use the indicated representation. 'X' (for the content of .X, usuaally normalised expression values) or any key for .obsm (e.g. X_pca for PCA) is valid. If not set, the representation is chosen automatically: For .n_vars < 50, .X is used, otherwise ‘X_pca’ is used. If ‘X_pca’ is not present, it’s computed with default parameters."/>
+    <param name="use_rep" argument="--use-rep" type="text" optional="true" label="Use the indicated representation" help="Use the indicated representation. 'X' (for the content of .X, usuaally normalised expression values) or any key for .obsm (e.g. X_pca for PCA) is valid. If not set, the representation is chosen automatically: For .n_vars less than 50, .X is used, otherwise ‘X_pca’ is used. If ‘X_pca’ is not present, it’s computed with default parameters."/>
     <conditional name="settings">
       <param name="default" type="boolean" checked="true" label="Use programme defaults"/>
       <when value="true"/>


### PR DESCRIPTION
# Description

Currently t-SNA and the graph step can take different inputs (.X, .obsm.X_pca), but these are limited to a select field so we can't use arbitrary values (e.g. X_pca_harmony). This PR makes it a text field instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
