### PR TITLE
Point at latest build of scanpy-scripts with fixed batch handling in scrublet

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -1,9 +1,11 @@
 <macros>
-  <token name="@TOOL_VERSION@">1.8.1</token>
+  <token name="@TOOL_VERSION@">1.8.1.1</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@PROFILE@">18.01</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
+
+1.8.1.1+galaxy0: Upate to scanpy-scripts 1.1.1 (running scanpy ==1.8.1), including improved Scrublet integration with batch handling.
 
 1.8.1+galaxy0: Upate to scanpy-scripts 1.0.1 (running scanpy ==1.8.1), including Scrublet integration.
 
@@ -61,7 +63,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="1.1.0">scanpy-scripts</requirement>
+      <requirement type="package" version="1.1.1">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -1,11 +1,11 @@
 <macros>
-  <token name="@TOOL_VERSION@">1.8.1.1</token>
+  <token name="@TOOL_VERSION@">1.8.1+1</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@PROFILE@">18.01</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
 
-1.8.1.1+galaxy0: Upate to scanpy-scripts 1.1.1 (running scanpy ==1.8.1), including improved Scrublet integration with batch handling.
+1.8.1.1+galaxy0: Upate to scanpy-scripts 1.1.1 build 1 (running scanpy ==1.8.1), including improved Scrublet integration with batch handling.
 
 1.8.1+galaxy0: Upate to scanpy-scripts 1.0.1 (running scanpy ==1.8.1), including Scrublet integration.
 


### PR DESCRIPTION
# Description

This PR just bumps the scanpy-scripts dependency to the [latest version](https://github.com/bioconda/bioconda-recipes/pull/29869) with a fix to batch handling in scrublet as well as a more basic fix to the scrublet process. 

The fix also fixes plotting, so multiple batches are handled automatically there too.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [x] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
