### PR TITLE
Bump scanpy-scripts to 1.1.2

### DIFF
--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>modifies metadata and flags genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
   <description>modifies metadata and flags genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_variable_genes" name="Scanpy FindVariableGenes" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="scanpy_find_variable_genes" name="Scanpy FindVariableGenes" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
   <description>based on normalised dispersion of expression</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_variable_genes" name="Scanpy FindVariableGenes" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_find_variable_genes" name="Scanpy FindVariableGenes" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>based on normalised dispersion of expression</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>to derive kNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
   <description>to derive kNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
+<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
   <description>visualise cell clusters using tSNE</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy1" profile="@PROFILE@">
+<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy0" profile="@PROFILE@">
   <description>visualise cell clusters using tSNE</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -1,11 +1,9 @@
 <macros>
-  <token name="@TOOL_VERSION@">1.8.2</token>
+  <token name="@TOOL_VERSION@">1.8.1+1</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@PROFILE@">18.01</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
-
-1.8.2+galaxy0: Upate to scanpy-scripts 1.1.2 (running scanpy ==1.8.1), including improved boolean handling
 
 1.8.1.1+galaxy0: Upate to scanpy-scripts 1.1.1 build 1 (running scanpy ==1.8.1), including improved Scrublet integration with batch handling.
 
@@ -65,7 +63,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="1.1.2">scanpy-scripts</requirement>
+      <requirement type="package" version="1.1.1">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -1,9 +1,11 @@
 <macros>
-  <token name="@TOOL_VERSION@">1.8.1+1</token>
+  <token name="@TOOL_VERSION@">1.8.2</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@PROFILE@">18.01</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
+
+1.8.2+galaxy0: Upate to scanpy-scripts 1.1.2 (running scanpy ==1.8.1), including improved boolean handling
 
 1.8.1.1+galaxy0: Upate to scanpy-scripts 1.1.1 build 1 (running scanpy ==1.8.1), including improved Scrublet integration with batch handling.
 
@@ -63,7 +65,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="1.1.1">scanpy-scripts</requirement>
+      <requirement type="package" version="1.1.2">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -1,11 +1,13 @@
 <macros>
-  <token name="@TOOL_VERSION@">1.8.1+1</token>
+  <token name="@TOOL_VERSION@">1.8.1+2</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@PROFILE@">18.01</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
 
-1.8.1.1+galaxy0: Upate to scanpy-scripts 1.1.1 build 1 (running scanpy ==1.8.1), including improved Scrublet integration with batch handling.
+1.8.1+2+galaxy0: Upate to scanpy-scripts 1.1.2 (running scanpy ==1.8.1), including improved boolean handling for mito etc.
+
+1.8.1+1+galaxy0: Upate to scanpy-scripts 1.1.1 build 1 (running scanpy ==1.8.1), including improved Scrublet integration with batch handling.
 
 1.8.1+galaxy0: Upate to scanpy-scripts 1.0.1 (running scanpy ==1.8.1), including Scrublet integration.
 
@@ -63,7 +65,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="1.1.1">scanpy-scripts</requirement>
+      <requirement type="package" version="1.1.2">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
# Description

Bumps the scanpy-wrappers to pull in the improve boolean handling in https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/109, which will in particular help with adding mitochondrial filtering to our pipelines.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [x] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
