### PR TITLE
Clarifies behaviour of "use_raw" checkbox in plot

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -55,7 +55,7 @@ $sort_order
     </param>
     <param name="groups" argument="--groups" type="text" value="" label="Key for categorical in `.obs`" help="You can pass your predefined groups by choosing any categorical annotation of observations."/>
     <param name="gene_symbols_field" argument="--gene-symbols" type="text" optional="true" label="Field for gene symbols" help="The field used in the AnnData object to store gene symbols, leave blank for the default (index), else a common value is 'gene_symbols'"/>
-    <param name="use_raw" argument="--use-raw" type="boolean" checked="true" truevalue="--use-raw" falsevalue="--no-raw" label="Use raw attributes if present"/>
+    <param name="use_raw" argument="--use-raw" type="boolean" checked="true" truevalue="--use-raw" falsevalue="--no-raw" label="Use raw attributes" help="Using this option means that scanpy will expect to find the raw data object. The job will fail if the raw data object is not present within the supplied AnnData file."/>
     <param name="layer" argument="--layer" value="" type="text"
         label="Name of the AnnData object layer to plot" help="By default adata.raw.X is plotted. If use_raw=False is set, then adata.X is plotted. If layer is set to a valid layer name, then the layer is plotted. layer takes precedence over use_raw." />
     <param name="neighbors_key" argument="--neighbors-key" value="" type="text"


### PR DESCRIPTION
# Description

Clarifies the behaviour of the "Use raw" checkbox in the plot embeddings tool, making explicit that if the raw data object is not present it will fail.

Fixes #244 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  

This is such a small change that I would rather just re-write the same tool-version + wrapper-version label. It has no impact in the actual computation or dependencies.