### PR TITLE
fix scanpy_scale_data when --save_layer option is set

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -41,7 +41,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
       --save-raw
     #end if
     #if $save_layer
-      --save-layer ${settings.save_layer}
+      --save-layer ${save_layer}
     #end if
   </token>
   <token name="@OUTPUT_OPTS@">


### PR DESCRIPTION
# Description

scanpy_scale_data and some of the other scanpy tool wrappers have the --save_layer option.  If this is set, its value is `${settings.save_layer}` which is an error because `settings` does not exist and the tool execution fails immediately.  The correct value for this is `${save_layer}`. This has probably arisen out of past refactoring of the wrappers.   

This is a bug fix rather than an enhancement or software update so I haven't bumped the version.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
