### PR TITLE
Add library-wise logic to atlas-fastq-provider wrapper

### DIFF
--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -61,7 +61,7 @@
 	    </param>
     </inputs>
     <outputs>
-        <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastq.gz"  />
+        <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz"  />
     </outputs>
     <tests>
         <test expect_num_outputs="1">

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -46,7 +46,7 @@
 
     <inputs>
         <conditional name="fetch_type">
-            <param name="script" argument="-a" type="select" label="Use file/URI or library" help="Download using a path (file or URI) or library ID" refresh_on_change="true">
+            <param name="script" argument="-a" type="select" label="Use file/URI or library" help="Download using a path (file or URI) or library ID" refresh_on_change="true" optional="false">
                 <option value="fetchFastq">File or URI</option>
                 <option value="fetchEnaLibraryFastqs" selected="true">Library</option>
             </param>
@@ -101,7 +101,7 @@
         <param name="config_file" argument="-c" type="data" format="atlas-fastq-provider-config.sh" label="config file to override defaults" help="config file to override defaults" optional='true'/>
     </inputs>
 
-    <outputs>
+<!--     <outputs>
         <conditional name="main_source">
             <when value="file_or_uri">
                 <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz" />
@@ -118,6 +118,20 @@
                 </conditional>
             </when>
         </conditional>
+    </outputs> -->
+
+    <outputs>
+        <data name="dl_from_path" label="Downloaded from path" format="fastqsanger.gz">
+            <filter>fetch_type[script] == "fetchFastq"</filter>
+        </data>
+        <data name="dl_from_lib_single" label="Downloaded library, single-end" format="fastqsanger.gz">
+            <filter>fetch_type[script] == "fetchEnaLibraryFastqs" and sepe == "SINGLE"</filter>
+        </data>
+        <collection name="dl_from_lib_paired" type="list">
+          <filter>fetch_type[script] == "fetchEnaLibraryFastqs" and sepe == "PAIRED"</filter>
+              <data name="lib_pair_1" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="lib_pair_1.fastq.gz"/>
+              <data name="lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="lib_pair_1.fastq.gz"/>
+        </collection>
     </outputs>
 
     <tests>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -7,15 +7,20 @@
         <requirement type="package" version="@TOOL_VERSION@">atlas-fastq-provider</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        fetchFastq.sh -f '$source' -t '$target'  
+        #if $mode:
+            #if $mode == "library_wise":
+            fetchEnaLibraryFastqs.sh -f '$source' -t '$target' -p '$mode'
+            #else:
+            fetchFastq.sh -f '$source' -t '$target' -p '$mode'
+            #end if
+        #else:
+            fetchFastq.sh -f '$source' -t '$target'  
+        #end if
         #if $resource
         -s '$resource' 
         #end if
         #if $retrieval_method
         -m '$retrieval_method'
-        #end if
-        #if $mode
-        -p '$mode'
         #end if
         #if $library
         -l '$library'
@@ -48,9 +53,11 @@
             <option value="ssh">SSH (ENA files, for EBI only)</option>
             <option value="http">HTTP endpoint (ENA files, EBI only)</option>
         </param>
-        <param name="mode" argument="-p" type="select" label="public or private, default public. Private usable by EBI staff only" help="public or private, default 'public' " optional='true'>
+        <param name="mode" argument="-p" type="select" label="public, private, or library_wise (default public). Private usable by EBI staff only" help="public, private or library_wise, default 'public' " optional='true'>
             <option value="public" selected="true">public</option>
             <option value="private">private</option>
+            <option value="library_wise">library_wise</option>
+
 	    </param>
         <param name="library" argument="-l" type="text"  label="ENA library (ENA source files only), by default inferred from file name" help="library, by default inferred from file name. E.g. -l ERR1888646 " optional='true'/>
         <param name="config_file" argument="-c" type="data" format="atlas-fastq-provider-config.sh" label="config file to override defaults" help="config file to override defaults" optional='true'/>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -68,7 +68,7 @@
             <when value="fetchEnaLibraryFastqs">
                 <param name="library" argument="-l" type="text"  label="ENA library (ENA source files only), by default inferred from file name" help="library, by default inferred from file name. E.g. -l ERR1888646" optional="false" />
                 <!-- Below possibly not needed if added to the command -->
-                <param name="output_dir" argument="-d" type="text" label="Output directory" help="Where files are saved" optional="false" />
+                <!-- <param name="output_dir" argument="-d" type="text" label="Output directory" help="Where files are saved" optional="false" /> -->
                 <param name="download_type" argument="-t" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional='true'>
                     <option value="fastq" selected="true">fastq</option>
                     <option value="srr">SRA</option>
@@ -130,23 +130,36 @@
         <collection name="dl_from_lib_paired" type="list">
           <filter>fetch_type[script] == "fetchEnaLibraryFastqs" and sepe == "PAIRED"</filter>
               <data name="lib_pair_1" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="lib_pair_1.fastq.gz"/>
-              <data name="lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="lib_pair_1.fastq.gz"/>
+              <data name="lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="lib_pair_2.fastq.gz"/>
         </collection>
     </outputs>
 
     <tests>
         <test expect_num_outputs="1">
-            <param name="main_source" value="file_or_uri"/>
-            <param name="source" value="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR035/ERR035229/ERR035229.fastq.gz"/>
+            <param name="script" value="fetchFastq"/>
+            <param name="path" value="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR035/ERR035229/ERR035229.fastq.gz"/>
             <param name="target" value="ERR035229.fastq.gz"/>
-            <output name="outfile"  md5="c9482e89552630084997112787a5d796" />   
+            <output name="dl_from_path" md5="c9482e89552630084997112787a5d796" />   
         </test>
         <test expect_num_outputs="1">
-            <param name="main_source" value="library"/>
+            <param name="script" value="fetchEnaLibraryFastqs"/>
             <param name="library" value="SRR18315788"/>
+            <!-- <param name="output_dir" value=""/> -->
             <param name="download_type" value="fastq"/>
             <param name="sepe" value="SINGLE"/>
-            <output name="outfile"  md5="5723e87046f61643803a9a3b99e138cb" />   
+            <output name="dl_from_lib_single" md5="5723e87046f61643803a9a3b99e138cb" />   
+        </test>
+        <test expect_num_outputs="2">
+            <param name="script" value="fetchEnaLibraryFastqs"/>
+            <param name="library" value="ERR2896350"/>
+            <!-- <param name="output_dir" value=""/> -->
+            <param name="download_type" value="fastq"/>
+            <param name="sepe" value="PARIED"/>
+            <output_collection name="dl_from_lib_paired" type="list">
+                <!-- md5 values are from https://www.ebi.ac.uk/ena/browser/api/xml/ERR2896350 -->
+                <element name="lib_pair_1" file="lib_pair_1.fastq.gz" md5="81ab2de51c3f1a2e28dc3aede000ed82"/>
+                <element name="lib_pair_2" file="lib_pair_2.fastq.gz" md5="b3bee670606ec4f0d8024ff97363e450"/>
+            </output_collection> 
         </test>
     </tests>
 

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -96,7 +96,22 @@
     </inputs>
 
     <outputs>
-        <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz"  />
+        <conditional name="main_source">
+            <when value="file_or_uri">
+                <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz"  />
+            </when>
+            <when value="file_or_uri">
+                <conditional name="sepe">
+                    <when value="SINGLE">
+                        <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz"  />
+                    </when>
+                    <when value="PAIRED">
+                        <data name="outfile_1" label="${tool.name} on ${on_string}: compressed fastq file _1" format="fastqsanger.gz" />
+                        <data name="outfile_2" label="${tool.name} on ${on_string}: compressed fastq file _2" format="fastqsanger.gz" />
+                    </when>
+                </conditional>
+            </when>
+        </conditional>
     </outputs>
 
     <tests>
@@ -106,7 +121,15 @@
             <param name="target" value="ERR035229.fastq.gz"/>
             <output name="outfile"  md5="c9482e89552630084997112787a5d796" />   
         </test>
+        <test expect_num_outputs="1">
+            <param name="main_source" value="library"/>
+            <param name="library" value="SRR18315788"/>
+            <param name="download_type" value="fastq"/>
+            <param name="sepe" value="SINGLE"/>
+            <output name="outfile"  md5="5723e87046f61643803a9a3b99e138cb" />   
+        </test>
     </tests>
+
     <help><![CDATA[
         
         Usage (<file or uri>  as main source): 

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_provider" name="Atlas FASTQ provider" version="@TOOL_VERSION@+galaxy1" python_template_version="3.5" profile="20.01">
+<tool id="fastq_provider" name="Atlas FASTQ provider" version="@TOOL_VERSION@+galaxy0" python_template_version="3.5" profile="20.01">
     <description> Retrieval and download of FASTQ files from ENA and other repositories such as HCA. The tool is used in production pipelines of EMBL-EBI Expression Atlas and Single Cell Expression Atlas.  </description>
     <macros>
         <token name="@TOOL_VERSION@">0.4.4</token>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -1,10 +1,7 @@
 <tool id="fastq_provider" name="Atlas FASTQ provider" version="@TOOL_VERSION@+galaxy" python_template_version="3.5" profile="20.01">
     <description> Retrieval and download of FASTQ files from ENA and other repositories such as HCA. The tool is used in production pipelines of EMBL-EBI Expression Atlas and Single Cell Expression Atlas.  </description>
-    <macros>
-        <token name="@TOOL_VERSION@">0.4.4</token>
-    </macros>
     <requirements>
-        <requirement type="package" version="@TOOL_VERSION@">atlas-fastq-provider</requirement>
+        <requirement type="package" version="0.4.4">atlas-fastq-provider</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_provider" name="Atlas FASTQ provider" version="@TOOL_VERSION@+galaxy" python_template_version="3.5" profile="20.01">
     <description> Retrieval and download of FASTQ files from ENA and other repositories such as HCA. The tool is used in production pipelines of EMBL-EBI Expression Atlas and Single Cell Expression Atlas.  </description>
     <macros>
-        <token name="@TOOL_VERSION@">0.4.2</token>
+        <token name="@TOOL_VERSION@">0.4.3</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">atlas-fastq-provider</requirement>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_provider" name="Atlas FASTQ provider" version="@TOOL_VERSION@+galaxy" python_template_version="3.5" profile="20.01">
+<tool id="fastq_provider" name="Atlas FASTQ provider" version="@TOOL_VERSION@+galaxy1" python_template_version="3.5" profile="20.01">
     <description> Retrieval and download of FASTQ files from ENA and other repositories such as HCA. The tool is used in production pipelines of EMBL-EBI Expression Atlas and Single Cell Expression Atlas.  </description>
     <macros>
         <token name="@TOOL_VERSION@">0.4.4</token>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -7,7 +7,7 @@
         <requirement type="package" version="@TOOL_VERSION@">atlas-fastq-provider</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        
+
         ${fetch_type.script}.sh 
 
         #if $fetch_type.script == "fetchFastq":
@@ -35,8 +35,8 @@
             #end if
         #end if
 
-        #if $fetch_type.retrieval_method:
-            -m ${fetch_type.retrieval_method}
+        #if $retrieval_method:
+            -m ${retrieval_method}
         #end if
 
         #if $config_file:
@@ -72,15 +72,6 @@
                 <param name="path" argument="-f" type="text" label="File or URI" help="Use a file path or URI." optional="false" />
                 <param name="target" argument="-t" type="text" label="Target file" help="Provide the target file name, e.g. 'ERR035229.fastq.gz'" optional="false" />
                 <param name="validate_only" argument="-v" type="boolean" label="Validate only, don't download" help="Check if you don't want to download and you only want to validate that a source URI is valid." checked="false" optional="true"/>
-                <param name="retrieval_method" argument="-m" type="select" label="Retrieval method" help="Retrieval method, default 'auto'. Files with HCA source will use the 'hca' download method regardless (-m will have no effect). Private ENA files will be fetched via 'ssh' (-m will have has no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource." optional="true">
-                    <option value="auto" selected="true">auto</option>
-                    <option value="wget">wget</option>
-                    <option value="dir">Local directory</option>
-                    <option value="hca">Human Cell Atlas</option>
-                    <option value="ssh">SSH (ENA files, for EBI only)</option>
-                    <option value="ftp">FTP (ENA files, for EBI only)</option>
-                    <option value="http">HTTP endpoint (ENA files, EBI only)</option>
-                </param>
                 <param name="library" argument="-l" type="text" label="ENA library (ENA source files only), by default inferred from file name" help="The library ID, which, by default, is inferred from file name. E.g. -l ERR1888646" optional="true"/>
             </when>
             <when value="fetchEnaLibraryFastqs">
@@ -95,17 +86,16 @@
                     <option value="PAIRED" selected="true">PAIRED</option>
                     <option value="SINGLE">SINGLE</option>
                 </param>
-                <param name="retrieval_method" argument="-m" type="select" label="Retrieval method" help="Retrieval method, default 'wget'. Files with HCA source will use the 'hca' download method regardless (-m will have no effect). Private ENA files will be fetched via 'ssh' (-m will have no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource." optional="true">
-                    <option value="auto">auto</option>
-                    <option value="wget" selected="true">wget</option>
-                    <option value="dir">Local directory</option>
-                    <option value="hca">Human Cell Atlas</option>
-                    <option value="ssh">SSH (ENA files, for EBI only)</option>
-                    <option value="ftp">FTP (ENA files, for EBI only)</option>
-                    <option value="http">HTTP endpoint (ENA files, EBI only)</option>
-                </param>
             </when>
         </conditional>
+        <param name="retrieval_method" argument="-m" type="select" label="Retrieval method" help="Retrieval method, default 'auto'. Files with HCA source will use the 'hca' download method regardless (-m will have no effect). Private ENA files will be fetched via 'ssh' (-m will have has no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource." optional="true">
+            <option value="auto" selected="true">auto</option>
+            <option value="wget">wget</option>
+            <option value="dir">Local directory</option>
+            <option value="ssh">SSH (ENA files, for EBI only)</option>
+            <option value="ftp">FTP (ENA files, for EBI only)</option>
+            <option value="http">HTTP endpoint (ENA files, EBI only)</option>
+        </param>
         <param name="resource" argument="-s" type="select" label="Resource or directory" help="How to fetch the file, e.g. there’s a specific method for getting results from the Human Cell Atlas' 'Azul' resource. Default: 'auto'." optional="true" >
             <option value="auto" selected="true">auto</option>
             <option value="ena">ENA</option>
@@ -116,7 +106,7 @@
             <option value="public" selected="true">public</option>
             <option value="private">private</option>
         </param>
-        <param name="config_file" argument="-c" type="data" format="atlas-fastq-provider-config.sh" label="config file to override defaults" help="config file to override defaults" optional="true"/>
+        <param name="config_file" argument="-c" type="data" format="text" label="Config file to override defaults" help="Config file to override defaults." optional="true"/>
     </inputs>
 
 <!--     <outputs>
@@ -140,13 +130,13 @@
 
     <outputs>
         <data name="dl_from_path" label="Downloaded from path" format="fastqsanger.gz" from_work_dir="dl_from_path.fastq.gz">
-            <filter>fetch_type[script] == "fetchFastq"</filter>
+            <filter>fetch_type["script"] == "fetchFastq"</filter>
         </data>
-        <data name="dl_from_lib_single" label="Downloaded library, single-end" format="fastqsanger.gz">
-            <filter>fetch_type[script] == "fetchEnaLibraryFastqs" and sepe == "SINGLE"</filter>
+        <data name="dl_from_lib_single" label="Downloaded library, single-end" format="fastqsanger.gz" from_work_dir="dl_from_lib_single.fastq.gz">
+            <filter>fetch_type["script"] == "fetchEnaLibraryFastqs" and fetch_type["sepe"] == "SINGLE"</filter>
         </data>
         <collection name="dl_from_lib_paired" type="list">
-          <filter>fetch_type[script] == "fetchEnaLibraryFastqs" and sepe == "PAIRED"</filter>
+          <filter>fetch_type["script"] == "fetchEnaLibraryFastqs" and fetch_type["sepe"] == "PAIRED"</filter>
               <data name="dl_from_lib_pair_1" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_1.fastq.gz"/>
               <data name="dl_from_lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_2.fastq.gz"/>
         </collection>
@@ -154,12 +144,27 @@
 
     <tests>
         <test>
-            <!-- test 2 -->
+            <param name="script" value="fetchFastq"/>
+            <param name="path" value="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR035/ERR035229/ERR035229.fastq.gz"/>
+            <param name="target" value="ERR035229.fastq.gz"/>
+            <output name="dl_from_path" md5="c9482e89552630084997112787a5d796" />   
+        </test>
+        <test>
             <param name="script" value="fetchEnaLibraryFastqs"/>
             <param name="library" value="SRR18315788"/>
             <param name="download_type" value="fastq"/>
             <param name="sepe" value="SINGLE"/>
             <output name="dl_from_lib_single" md5="5723e87046f61643803a9a3b99e138cb" />   
+        </test>
+        <test>
+            <param name="script" value="fetchEnaLibraryFastqs"/>
+            <param name="library" value="ERR2890000"/>
+            <param name="download_type" value="fastq"/>
+            <param name="sepe" value="PAIRED"/>
+            <output_collection name="dl_from_lib_paired" type="list">
+                <element name="dl_from_lib_pair_1" md5="6ef420b74010b4f3918476909967fd18"/>
+                <element name="dl_from_lib_pair_2" md5="f70d8209cf8b0617f4adc75c0a13713a"/>
+            </output_collection> 
         </test>
     </tests>
 

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -42,25 +42,33 @@
         #if $main_source == 'file_or_uri':
         ; mv -f '$target' '$outfile' 
         #end if
-    ]]></command> 
-    <inputs>
+    ]]></command>
 
-        <conditional name="fetchFastq">
-            <param name="main_source" argument="-a" type="select" label="file_or_uri or library" help="file_or_uri or library" >
-                <option value="library" selected="true">public</option>
-                <option value="file_or_uri">private</option>
+    <inputs>
+        <conditional name="fetch_type">
+            <param name="script" argument="-a" type="select" label="Use file/URI or library" help="Download using a path (file or URI) or library ID" refresh_on_change="true">
+                <option value="fetchFastq">File or URI</option>
+                <option value="fetchEnaLibraryFastqs" selected="true">Library</option>
             </param>
-            <when value="file_or_uri">
-                <param name="source" argument="-f" type="text" label="file or uri" help="file or uri" />
-                <param name="target" argument="-t" type="text"  label="target file" help="target file. E.g 'ERR035229.fastq.gz' " />
-                <param name="validate_only" argument="-v" type="boolean" label="validate only to check a source URI is valid, don't download" help="validate only, don't download" optional='true'/>
-                <param name="download_type" argument="-d" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional='true'>
-                    <option value="fastq" selected="true">fastq</option>
-                    <option value="srr">SRA</option>
+            <when value="fetchFastq">
+                <param name="path" argument="-f" type="text" label="File or URI" help="File path or URI" optional="false" />
+                <param name="target" argument="-t" type="text"  label="target file" help="target file. E.g 'ERR035229.fastq.gz'" optional="false" />
+                <param name="validate_only" argument="-v" type="boolean" label="validate only to check a source URI is valid, don't download" help="Validate only, don't download" optional='true' />
+                <param name="retrieval_method" argument="-m" type="select"  label="retrieval method, default 'wget' "  help="retrieval method, default 'auto'. Files with hca source will use the 'hca' download method regardless (-m has no effect). Private ENA files will be fetched via 'ssh' (-m has no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource. "  optional='true'>
+                    <option value="auto" selected="true">auto</option>
+                    <option value="wget">wget</option>
+                    <option value="dir">Local directory</option>
+                    <option value="hca">Human Cell Atlas</option>
+                    <option value="ssh">SSH (ENA files, for EBI only)</option>
+                    <option value="ftp">FTP (ENA files, for EBI only)</option>
+                    <option value="http">HTTP endpoint (ENA files, EBI only)</option>
                 </param>
+                <param name="library" argument="-l" type="text"  label="ENA library (ENA source files only), by default inferred from file name" help="library, by default inferred from file name. E.g. -l ERR1888646" optional="true"/>
             </when>
-            <when value="library">
-                <param name="library" argument="-l" type="text" label="library" help="library" />
+            <when value="fetchEnaLibraryFastqs">
+                <param name="library" argument="-l" type="text"  label="ENA library (ENA source files only), by default inferred from file name" help="library, by default inferred from file name. E.g. -l ERR1888646" optional="false" />
+                <!-- Below possibly not needed if added to the command -->
+                <param name="output_dir" argument="-d" type="text" label="Output directory" help="Where files are saved" optional="false" />
                 <param name="download_type" argument="-t" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional='true'>
                     <option value="fastq" selected="true">fastq</option>
                     <option value="srr">SRA</option>
@@ -69,30 +77,28 @@
                     <option value="PAIRED" selected="true">PAIRED</option>
                     <option value="SINGLE">SINGLE</option>
                 </param>
+                <param name="retrieval_method" argument="-m" type="select"  label="retrieval method, default 'wget' "  help="retrieval method, default 'auto'. Files with hca source will use the 'hca' download method regardless (-m has no effect). Private ENA files will be fetched via 'ssh' (-m has no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource. "  optional='true'>
+                    <option value="auto">auto</option>
+                    <option value="wget" selected="true">wget</option>
+                    <option value="dir">Local directory</option>
+                    <option value="hca">Human Cell Atlas</option>
+                    <option value="ssh">SSH (ENA files, for EBI only)</option>
+                    <option value="ftp">FTP (ENA files, for EBI only)</option>
+                    <option value="http">HTTP endpoint (ENA files, EBI only)</option>
+                </param>
             </when>
         </conditional>
-
         <param name="resource" argument="-s" type="select"  label="resource or directory, default 'auto' " help="How to fetch the file, e.g. there’s a specific method for getting results from the Human Cell Atlas' 'Azul' resource. " optional='true' >
             <option value="auto" selected="true">auto</option>
             <option value="ena">ENA</option>
             <option value="sra">SRA file</option>
             <option value="hca">Human Cell Atlas</option>
-            <option value="dir">Local directory</option>
-	    </param>
-        <param name="retrieval_method" argument="-m" type="select"  label="retrieval method, default 'wget' "  help="retrieval method, default 'auto'. Files with hca source will use the 'hca' download method regardless (-m has no effect). Private ENA files will be fetched via 'ssh' (-m has no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource. "  optional='true'>
-            <option value="auto" selected="true">auto</option>
-            <option value="wget">wget</option>
-            <option value="dir">Local directory</option>
-            <option value="ssh">SSH (ENA files, for EBI only)</option>
-            <option value="http">HTTP endpoint (ENA files, EBI only)</option>
         </param>
         <param name="mode" argument="-p" type="select" label="public or private, default public. Private usable by EBI staff only" help="public or private, default 'public' " optional='true'>
             <option value="public" selected="true">public</option>
             <option value="private">private</option>
-	    </param>
-        <param name="library" argument="-l" type="text"  label="ENA library (ENA source files only), by default inferred from file name" help="library, by default inferred from file name. E.g. -l ERR1888646 " optional='true'/>
+        </param>
         <param name="config_file" argument="-c" type="data" format="atlas-fastq-provider-config.sh" label="config file to override defaults" help="config file to override defaults" optional='true'/>
-
     </inputs>
 
     <outputs>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -120,12 +120,24 @@
     </outputs>
     <tests>
         <test>
+            <param name="script" value="fetchFastq"/>
+            <param name="path" value="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR035/ERR035229/ERR035229.fastq.gz"/>
+            <param name="target" value="ERR035229.fastq.gz"/>
+            <output name="dl_from_path" md5="c9482e89552630084997112787a5d796" />   
+        </test>
+        <test>
+            <param name="script" value="fetchEnaLibraryFastqs"/>
+            <param name="library" value="SRR18315788"/>
+            <param name="download_type" value="fastq"/>
+            <param name="sepe" value="SINGLE"/>
+            <output name="dl_from_lib_single" md5="5723e87046f61643803a9a3b99e138cb" />   
+        </test>
+        <test>
             <param name="script" value="fetchEnaLibraryFastqs"/>
             <param name="library" value="ERR2890000"/>
             <param name="download_type" value="fastq"/>
             <param name="sepe" value="PAIRED"/>
-            <!-- <param name="retrieval_method" value="wget"/> -->
-            <!-- <param name="resource" value="ena"/> -->
+            <param name="resource" value="ena"/>
             <output_collection name="dl_from_lib_paired" type="paired">
                 <element name="forward" md5="6ef420b74010b4f3918476909967fd18"/>
                 <element name="reverse" md5="f70d8209cf8b0617f4adc75c0a13713a"/>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -115,7 +115,7 @@
         <data name="dl_from_lib_single" label="Downloaded library, single-end" format="fastqsanger.gz" from_work_dir="dl_from_lib_single.fastq.gz">
             <filter>fetch_type["script"] == "fetchEnaLibraryFastqs" and fetch_type["sepe"] == "SINGLE"</filter>
         </data>
-        <collection name="dl_from_lib_paired" type="list">
+        <collection name="dl_from_lib_paired" type="paired">
           <filter>fetch_type["script"] == "fetchEnaLibraryFastqs" and fetch_type["sepe"] == "PAIRED"</filter>
               <data name="dl_from_lib_pair_1" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_1.fastq.gz"/>
               <data name="dl_from_lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_2.fastq.gz"/>
@@ -140,7 +140,7 @@
             <param name="library" value="ERR2890000"/>
             <param name="download_type" value="fastq"/>
             <param name="sepe" value="PAIRED"/>
-            <output_collection name="dl_from_lib_paired" type="list">
+            <output_collection name="dl_from_lib_paired" type="paired">
                 <element name="dl_from_lib_pair_1" md5="6ef420b74010b4f3918476909967fd18"/>
                 <element name="dl_from_lib_pair_2" md5="f70d8209cf8b0617f4adc75c0a13713a"/>
             </output_collection> 

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -7,40 +7,50 @@
         <requirement type="package" version="@TOOL_VERSION@">atlas-fastq-provider</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        #if $main_source == 'file_or_uri':
-        fetchFastq.sh -f '$source' -t '$target'
-            #if $validate_only:
-            -v '$validate_only'
-            #end if
-            #if $download_type:
-            -d '$download_type'
-            #end if
-        #else:
-        fetchEnaLibraryFastqs.sh -l '$library' -d ./
-            #if $sepe:
-            -n '$sepe'
-            #end if
-            #if $download_type:
-            -t '$download_type'
-            #end if
+        ${fetch_type.script}.sh 
+
+        #if $path
+        -f '${path}' 
         #end if
-        #if $resource
-        -s '$resource' 
+
+        #if $target
+        -t '${target}' 
         #end if
-        #if $retrieval_method
-        -m '$retrieval_method'
-        #end if
+
         #if $library
-        -l '$library'
+        -l '${library}' 
         #end if
+
+        #if $retrieval_method
+        -m '${retrieval_method}'
+        #end if
+
         #if $config_file
-        -c '$config_file'
+        -c '${config_file}'
         #end if
+
+        #if $resource
+        -s '${resource}' 
+        #end if
+
         #if $mode
-        -p '$mode'
+        -p '${mode}'
         #end if
-        #if $main_source == 'file_or_uri':
-        ; mv -f '$target' '$outfile' 
+
+        #if $download_type
+        -t '${download_type}' 
+        #end if
+
+        #if $sepe
+        -n '${sepe}' 
+        #end if
+
+        #if $fetch_type.script == "fetchFastq":
+            #if $validate_only
+            -v
+            #end if
+        #else if $fetch_type.script == "fetchEnaLibraryFastqs":
+            -d ''
         #end if
     ]]></command>
 
@@ -129,8 +139,8 @@
         </data>
         <collection name="dl_from_lib_paired" type="list">
           <filter>fetch_type[script] == "fetchEnaLibraryFastqs" and sepe == "PAIRED"</filter>
-              <data name="lib_pair_1" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="lib_pair_1.fastq.gz"/>
-              <data name="lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="lib_pair_2.fastq.gz"/>
+              <data name="lib_pair_1" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="*_1.fastq.gz"/>
+              <data name="lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="*_2.fastq.gz"/>
         </collection>
     </outputs>
 
@@ -157,8 +167,8 @@
             <param name="sepe" value="PARIED"/>
             <output_collection name="dl_from_lib_paired" type="list">
                 <!-- md5 values are from https://www.ebi.ac.uk/ena/browser/api/xml/ERR2896350 -->
-                <element name="lib_pair_1" file="lib_pair_1.fastq.gz" md5="81ab2de51c3f1a2e28dc3aede000ed82"/>
-                <element name="lib_pair_2" file="lib_pair_2.fastq.gz" md5="b3bee670606ec4f0d8024ff97363e450"/>
+                <element name="lib_pair_1" md5="81ab2de51c3f1a2e28dc3aede000ed82"/>
+                <element name="lib_pair_2" md5="b3bee670606ec4f0d8024ff97363e450"/>
             </output_collection> 
         </test>
     </tests>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -1,15 +1,13 @@
 <tool id="fastq_provider" name="Atlas FASTQ provider" version="@TOOL_VERSION@+galaxy" python_template_version="3.5" profile="20.01">
     <description> Retrieval and download of FASTQ files from ENA and other repositories such as HCA. The tool is used in production pipelines of EMBL-EBI Expression Atlas and Single Cell Expression Atlas.  </description>
     <macros>
-        <token name="@TOOL_VERSION@">0.4.3</token>
+        <token name="@TOOL_VERSION@">0.4.4</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">atlas-fastq-provider</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-
-        which fetchEnaLibraryFastqs.sh #############
-
+        
         ${fetch_type.script}.sh 
 
         #if $fetch_type.script == "fetchFastq":

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -7,64 +7,74 @@
         <requirement type="package" version="@TOOL_VERSION@">atlas-fastq-provider</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
+
+        which fetchEnaLibraryFastqs.sh #############
+
         ${fetch_type.script}.sh 
 
-        #if $path
-        -f '${path}' 
+        #if $fetch_type.script == "fetchFastq":
+            -f "${fetch_type.path}"
+            -t "${fetch_type.target}"
+
+            #if $fetch_type.library:
+                -l ${fetch_type.library}
+            #end if
+            
+            #if $fetch_type.validate_only:
+                -v
+            #end if
+        
+        #else if $fetch_type.script == "fetchEnaLibraryFastqs":
+            -l ${fetch_type.library}
+            -d "./"
+        
+            #if $fetch_type.download_type:
+                -t ${fetch_type.download_type}
+            #end if
+        
+            #if $fetch_type.sepe:
+                -n ${fetch_type.sepe}
+            #end if
         #end if
 
-        #if $target
-        -t '${target}' 
+        #if $fetch_type.retrieval_method:
+            -m ${fetch_type.retrieval_method}
         #end if
 
-        #if $library
-        -l '${library}' 
+        #if $config_file:
+            -c ${config_file}
         #end if
 
-        #if $retrieval_method
-        -m '${retrieval_method}'
+        #if $resource:
+            -s ${resource}
         #end if
 
-        #if $config_file
-        -c '${config_file}'
-        #end if
-
-        #if $resource
-        -s '${resource}' 
-        #end if
-
-        #if $mode
-        -p '${mode}'
-        #end if
-
-        #if $download_type
-        -t '${download_type}' 
-        #end if
-
-        #if $sepe
-        -n '${sepe}' 
+        #if $mode:
+            -p ${mode}
         #end if
 
         #if $fetch_type.script == "fetchFastq":
-            #if $validate_only
-            -v
-            #end if
+            ; mv -f "${fetch_type.target}" dl_from_path.fastq.gz
         #else if $fetch_type.script == "fetchEnaLibraryFastqs":
-            -d ''
+            #if $fetch_type.sepe == "SINGLE":
+                ; mv -f "${fetch_type.library}.fastq.gz" dl_from_lib_single.fastq.gz
+            #else if $fetch_type.sepe == "PAIRED":
+                ; mv -f "${fetch_type.library}_1.fastq.gz" dl_from_lib_pair_1.fastq.gz
+                ; mv -f "${fetch_type.library}_2.fastq.gz" dl_from_lib_pair_2.fastq.gz
+            #end if
         #end if
     ]]></command>
-
     <inputs>
         <conditional name="fetch_type">
-            <param name="script" argument="-a" type="select" label="Use file/URI or library" help="Download using a path (file or URI) or library ID" refresh_on_change="true" optional="false">
+            <param name="script" argument="-a" type="select" label="Use file/URI or library" help="Download using a path (file or URI) or library ID." refresh_on_change="true" optional="false">
                 <option value="fetchFastq">File or URI</option>
                 <option value="fetchEnaLibraryFastqs" selected="true">Library</option>
             </param>
             <when value="fetchFastq">
-                <param name="path" argument="-f" type="text" label="File or URI" help="File path or URI" optional="false" />
-                <param name="target" argument="-t" type="text"  label="target file" help="target file. E.g 'ERR035229.fastq.gz'" optional="false" />
-                <param name="validate_only" argument="-v" type="boolean" label="validate only to check a source URI is valid, don't download" help="Validate only, don't download" optional='true' />
-                <param name="retrieval_method" argument="-m" type="select"  label="retrieval method, default 'wget' "  help="retrieval method, default 'auto'. Files with hca source will use the 'hca' download method regardless (-m has no effect). Private ENA files will be fetched via 'ssh' (-m has no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource. "  optional='true'>
+                <param name="path" argument="-f" type="text" label="File or URI" help="Use a file path or URI." optional="false" />
+                <param name="target" argument="-t" type="text" label="Target file" help="Provide the target file name, e.g. 'ERR035229.fastq.gz'" optional="false" />
+                <param name="validate_only" argument="-v" type="boolean" label="Validate only, don't download" help="Check if you don't want to download and you only want to validate that a source URI is valid." checked="false" optional="true"/>
+                <param name="retrieval_method" argument="-m" type="select" label="Retrieval method" help="Retrieval method, default 'auto'. Files with HCA source will use the 'hca' download method regardless (-m will have no effect). Private ENA files will be fetched via 'ssh' (-m will have has no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource." optional="true">
                     <option value="auto" selected="true">auto</option>
                     <option value="wget">wget</option>
                     <option value="dir">Local directory</option>
@@ -73,21 +83,21 @@
                     <option value="ftp">FTP (ENA files, for EBI only)</option>
                     <option value="http">HTTP endpoint (ENA files, EBI only)</option>
                 </param>
-                <param name="library" argument="-l" type="text"  label="ENA library (ENA source files only), by default inferred from file name" help="library, by default inferred from file name. E.g. -l ERR1888646" optional="true"/>
+                <param name="library" argument="-l" type="text" label="ENA library (ENA source files only), by default inferred from file name" help="The library ID, which, by default, is inferred from file name. E.g. -l ERR1888646" optional="true"/>
             </when>
             <when value="fetchEnaLibraryFastqs">
-                <param name="library" argument="-l" type="text"  label="ENA library (ENA source files only), by default inferred from file name" help="library, by default inferred from file name. E.g. -l ERR1888646" optional="false" />
+                <param name="library" argument="-l" type="text" label="ENA library (ENA source files only), by default inferred from file name" help="The library ID, which, by default, is inferred from file name. E.g. -l ERR1888646" optional="false"/>
                 <!-- Below possibly not needed if added to the command -->
                 <!-- <param name="output_dir" argument="-d" type="text" label="Output directory" help="Where files are saved" optional="false" /> -->
-                <param name="download_type" argument="-t" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional='true'>
+                <param name="download_type" argument="-t" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional="true">
                     <option value="fastq" selected="true">fastq</option>
                     <option value="srr">SRA</option>
                 </param>
-                <param name="sepe" argument="-n" type="select" label="SINGLE-end or PAIRED-end, default PAIRED" help="SINGLE-end or PAIRED-end, default PAIRED" optional='true'>
+                <param name="sepe" argument="-n" type="select" label="SINGLE-end or PAIRED-end" help="SINGLE-end or PAIRED-end, default PAIRED" optional="true">
                     <option value="PAIRED" selected="true">PAIRED</option>
                     <option value="SINGLE">SINGLE</option>
                 </param>
-                <param name="retrieval_method" argument="-m" type="select"  label="retrieval method, default 'wget' "  help="retrieval method, default 'auto'. Files with hca source will use the 'hca' download method regardless (-m has no effect). Private ENA files will be fetched via 'ssh' (-m has no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource. "  optional='true'>
+                <param name="retrieval_method" argument="-m" type="select" label="Retrieval method" help="Retrieval method, default 'wget'. Files with HCA source will use the 'hca' download method regardless (-m will have no effect). Private ENA files will be fetched via 'ssh' (-m will have no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource." optional="true">
                     <option value="auto">auto</option>
                     <option value="wget" selected="true">wget</option>
                     <option value="dir">Local directory</option>
@@ -98,17 +108,17 @@
                 </param>
             </when>
         </conditional>
-        <param name="resource" argument="-s" type="select"  label="resource or directory, default 'auto' " help="How to fetch the file, e.g. there’s a specific method for getting results from the Human Cell Atlas' 'Azul' resource. " optional='true' >
+        <param name="resource" argument="-s" type="select" label="Resource or directory" help="How to fetch the file, e.g. there’s a specific method for getting results from the Human Cell Atlas' 'Azul' resource. Default: 'auto'." optional="true" >
             <option value="auto" selected="true">auto</option>
             <option value="ena">ENA</option>
             <option value="sra">SRA file</option>
             <option value="hca">Human Cell Atlas</option>
         </param>
-        <param name="mode" argument="-p" type="select" label="public or private, default public. Private usable by EBI staff only" help="public or private, default 'public' " optional='true'>
+        <param name="mode" argument="-p" type="select" label="Public or private" help="Public or private, defaults to public. Private usable by EBI staff only." optional="true">
             <option value="public" selected="true">public</option>
             <option value="private">private</option>
         </param>
-        <param name="config_file" argument="-c" type="data" format="atlas-fastq-provider-config.sh" label="config file to override defaults" help="config file to override defaults" optional='true'/>
+        <param name="config_file" argument="-c" type="data" format="atlas-fastq-provider-config.sh" label="config file to override defaults" help="config file to override defaults" optional="true"/>
     </inputs>
 
 <!--     <outputs>
@@ -131,7 +141,7 @@
     </outputs> -->
 
     <outputs>
-        <data name="dl_from_path" label="Downloaded from path" format="fastqsanger.gz">
+        <data name="dl_from_path" label="Downloaded from path" format="fastqsanger.gz" from_work_dir="dl_from_path.fastq.gz">
             <filter>fetch_type[script] == "fetchFastq"</filter>
         </data>
         <data name="dl_from_lib_single" label="Downloaded library, single-end" format="fastqsanger.gz">
@@ -139,37 +149,19 @@
         </data>
         <collection name="dl_from_lib_paired" type="list">
           <filter>fetch_type[script] == "fetchEnaLibraryFastqs" and sepe == "PAIRED"</filter>
-              <data name="lib_pair_1" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="*_1.fastq.gz"/>
-              <data name="lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="*_2.fastq.gz"/>
+              <data name="dl_from_lib_pair_1" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_1.fastq.gz"/>
+              <data name="dl_from_lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_2.fastq.gz"/>
         </collection>
     </outputs>
 
     <tests>
-        <test expect_num_outputs="1">
-            <param name="script" value="fetchFastq"/>
-            <param name="path" value="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR035/ERR035229/ERR035229.fastq.gz"/>
-            <param name="target" value="ERR035229.fastq.gz"/>
-            <output name="dl_from_path" md5="c9482e89552630084997112787a5d796" />   
-        </test>
-        <test expect_num_outputs="1">
+        <test>
+            <!-- test 2 -->
             <param name="script" value="fetchEnaLibraryFastqs"/>
             <param name="library" value="SRR18315788"/>
-            <!-- <param name="output_dir" value=""/> -->
             <param name="download_type" value="fastq"/>
             <param name="sepe" value="SINGLE"/>
             <output name="dl_from_lib_single" md5="5723e87046f61643803a9a3b99e138cb" />   
-        </test>
-        <test expect_num_outputs="2">
-            <param name="script" value="fetchEnaLibraryFastqs"/>
-            <param name="library" value="ERR2896350"/>
-            <!-- <param name="output_dir" value=""/> -->
-            <param name="download_type" value="fastq"/>
-            <param name="sepe" value="PARIED"/>
-            <output_collection name="dl_from_lib_paired" type="list">
-                <!-- md5 values are from https://www.ebi.ac.uk/ena/browser/api/xml/ERR2896350 -->
-                <element name="lib_pair_1" md5="81ab2de51c3f1a2e28dc3aede000ed82"/>
-                <element name="lib_pair_2" md5="b3bee670606ec4f0d8024ff97363e450"/>
-            </output_collection> 
         </test>
     </tests>
 

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -1,7 +1,10 @@
 <tool id="fastq_provider" name="Atlas FASTQ provider" version="@TOOL_VERSION@+galaxy" python_template_version="3.5" profile="20.01">
     <description> Retrieval and download of FASTQ files from ENA and other repositories such as HCA. The tool is used in production pipelines of EMBL-EBI Expression Atlas and Single Cell Expression Atlas.  </description>
+    <macros>
+        <token name="@TOOL_VERSION@">0.4.4</token>
+    </macros>
     <requirements>
-        <requirement type="package" version="0.4.4">atlas-fastq-provider</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">atlas-fastq-provider</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -98,12 +98,12 @@
     <outputs>
         <conditional name="main_source">
             <when value="file_or_uri">
-                <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz"  />
+                <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz" />
             </when>
-            <when value="file_or_uri">
+            <when value="library">
                 <conditional name="sepe">
                     <when value="SINGLE">
-                        <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz"  />
+                        <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz" />
                     </when>
                     <when value="PAIRED">
                         <data name="outfile_1" label="${tool.name} on ${on_string}: compressed fastq file _1" format="fastqsanger.gz" />

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -16,7 +16,7 @@
             -d '$download_type'
             #end if
         #else:
-        fetchEnaLibraryFastqs.sh -l '$library' -d '$output_directory'
+        fetchEnaLibraryFastqs.sh -l '$library' -d ./
             #if $sepe:
             -n '$sepe'
             #end if
@@ -61,7 +61,6 @@
             </when>
             <when value="library">
                 <param name="library" argument="-l" type="text" label="library" help="library" />
-                <param name="output_directory" argument="-d" type="text" label="output directory" help="output directory" />
                 <param name="download_type" argument="-t" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional='true'>
                     <option value="fastq" selected="true">fastq</option>
                     <option value="srr">SRA</option>
@@ -95,9 +94,11 @@
         <param name="config_file" argument="-c" type="data" format="atlas-fastq-provider-config.sh" label="config file to override defaults" help="config file to override defaults" optional='true'/>
 
     </inputs>
+
     <outputs>
         <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz"  />
     </outputs>
+
     <tests>
         <test expect_num_outputs="1">
             <param name="main_source" value="file_or_uri"/>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -151,7 +151,7 @@
         
         Usage (<library> as main source): 
 
-            fetchEnaLibraryFastqs.sh -l <library> -d <output directory> [-m <retrieval method, default 'wget'>] [-s <source directory for method 'dir'>] [-p <public or private, default public>] [-c <config file to override defaults>] [-t <download type, fastq or srr>] [-n <SINGLE or PAIRED, default PAIRED>]
+            fetchEnaLibraryFastqs.sh -l <library> -d <output directory> [-m <retrieval method, default 'auto'>] [-s <source directory for method 'dir'>] [-p <public or private, default public>] [-c <config file to override defaults>] [-t <download type, fastq or srr>] [-n <SINGLE or PAIRED, default PAIRED>]
 
     ]]></help>
     <citations>
@@ -166,4 +166,3 @@
         }</citation>
     </citations>
 </tool>
-

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -53,7 +53,7 @@
             <option value="ssh">SSH (ENA files, for EBI only)</option>
             <option value="http">HTTP endpoint (ENA files, EBI only)</option>
         </param>
-        <param name="mode" argument="-p" type="select" label="public, private, or library_wise (default public). Private usable by EBI staff only" help="public, private or library_wise, default 'public' " optional='true'>
+        <param name="mode" argument="-p" type="select" label="public or private, default public. Private usable by EBI staff only" help="public or private, default 'public' " optional='true'>
             <option value="public" selected="true">public</option>
             <option value="private">private</option>
             <option value="library_wise">library_wise</option>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -117,7 +117,9 @@
             fetchEnaLibraryFastqs.sh -l <library> -d <output directory> [-m <retrieval method, default 'wget'>] [-s <source directory for method 'dir'>] [-p <public or private, default public>] [-c <config file to override defaults>] [-t <download type, fastq or srr>] [-n <SINGLE or PAIRED, default PAIRED>]
 
     ]]></help>
+
     <citations>
+
         <citation type="bibtex">
             @misc{githubatlas-fastq-provider,
             author = {Jonathan Manning, EBI Gene Expression Team},
@@ -127,6 +129,8 @@
             journal = {GitHub repository},
             url = {https://github.com/ebi-gene-expression-group/atlas-fastq-provider},
         }</citation>
+        
     </citations>
+
 </tool>
 

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -76,8 +76,6 @@
             </when>
             <when value="fetchEnaLibraryFastqs">
                 <param name="library" argument="-l" type="text" label="ENA library (ENA source files only), by default inferred from file name" help="The library ID, which, by default, is inferred from file name. E.g. -l ERR1888646" optional="false"/>
-                <!-- Below possibly not needed if added to the command -->
-                <!-- <param name="output_dir" argument="-d" type="text" label="Output directory" help="Where files are saved" optional="false" /> -->
                 <param name="download_type" argument="-t" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional="true">
                     <option value="fastq" selected="true">fastq</option>
                     <option value="srr">SRA</option>
@@ -90,7 +88,6 @@
         </conditional>
         <param name="retrieval_method" argument="-m" type="select" label="Retrieval method" help="Retrieval method, default 'auto'. Files with HCA source will use the 'hca' download method regardless (-m will have no effect). Private ENA files will be fetched via 'ssh' (-m will have has no effect). The 'http' method refers to an HTTP endpoint in the EBI Fire resource." optional="true">
             <option value="auto" selected="true">auto</option>
-            <option value="wget">wget</option>
             <option value="dir">Local directory</option>
             <option value="ssh">SSH (ENA files, for EBI only)</option>
             <option value="ftp">FTP (ENA files, for EBI only)</option>
@@ -117,32 +114,21 @@
         </data>
         <collection name="dl_from_lib_paired" type="paired">
           <filter>fetch_type["script"] == "fetchEnaLibraryFastqs" and fetch_type["sepe"] == "PAIRED"</filter>
-              <data name="dl_from_lib_pair_1" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_1.fastq.gz"/>
-              <data name="dl_from_lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_2.fastq.gz"/>
+              <data name="forward" label="Downloaded library, pair read 1" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_1.fastq.gz"/>
+              <data name="reverse" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_2.fastq.gz"/>
         </collection>
     </outputs>
     <tests>
-        <test>
-            <param name="script" value="fetchFastq"/>
-            <param name="path" value="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR035/ERR035229/ERR035229.fastq.gz"/>
-            <param name="target" value="ERR035229.fastq.gz"/>
-            <output name="dl_from_path" md5="c9482e89552630084997112787a5d796" />   
-        </test>
-        <test>
-            <param name="script" value="fetchEnaLibraryFastqs"/>
-            <param name="library" value="SRR18315788"/>
-            <param name="download_type" value="fastq"/>
-            <param name="sepe" value="SINGLE"/>
-            <output name="dl_from_lib_single" md5="5723e87046f61643803a9a3b99e138cb" />   
-        </test>
         <test>
             <param name="script" value="fetchEnaLibraryFastqs"/>
             <param name="library" value="ERR2890000"/>
             <param name="download_type" value="fastq"/>
             <param name="sepe" value="PAIRED"/>
+            <!-- <param name="retrieval_method" value="wget"/> -->
+            <!-- <param name="resource" value="ena"/> -->
             <output_collection name="dl_from_lib_paired" type="paired">
-                <element name="dl_from_lib_pair_1" md5="6ef420b74010b4f3918476909967fd18"/>
-                <element name="dl_from_lib_pair_2" md5="f70d8209cf8b0617f4adc75c0a13713a"/>
+                <element name="forward" md5="6ef420b74010b4f3918476909967fd18"/>
+                <element name="reverse" md5="f70d8209cf8b0617f4adc75c0a13713a"/>
             </output_collection> 
         </test>
     </tests>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -7,14 +7,22 @@
         <requirement type="package" version="@TOOL_VERSION@">atlas-fastq-provider</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        #if $mode:
-            #if $mode == "library_wise":
-            fetchEnaLibraryFastqs.sh -f '$source' -t '$target' -p '$mode'
-            #else:
-            fetchFastq.sh -f '$source' -t '$target' -p '$mode'
+        #if $main_source == 'file_or_uri':
+        fetchFastq.sh -f '$source' -t '$target'
+            #if $validate_only:
+            -v '$validate_only'
+            #end if
+            #if $download_type:
+            -d '$download_type'
             #end if
         #else:
-            fetchFastq.sh -f '$source' -t '$target'  
+        fetchEnaLibraryFastqs.sh -l '$library' -d '$output_directory'
+            #if $sepe:
+            -n '$sepe'
+            #end if
+            #if $download_type:
+            -t '$download_type'
+            #end if
         #end if
         #if $resource
         -s '$resource' 
@@ -28,17 +36,43 @@
         #if $config_file
         -c '$config_file'
         #end if
-        #if $validate_only
-        -v '$validate_only'
+        #if $mode
+        -p '$mode'
         #end if
-        #if $download_type
-        -d '$download_type' 
-        #end if
+        #if $main_source == 'file_or_uri':
         ; mv -f '$target' '$outfile' 
+        #end if
     ]]></command> 
     <inputs>
-        <param name="source" argument="-f" type="text" label="file or uri" help="file or uri" />
-        <param name="target" argument="-t" type="text"  label="target file" help="target file. E.g 'ERR035229.fastq.gz' " />
+
+        <conditional name="fetchFastq">
+            <param name="main_source" argument="-a" type="select" label="file_or_uri or library" help="file_or_uri or library" >
+                <option value="library" selected="true">public</option>
+                <option value="file_or_uri">private</option>
+            </param>
+            <when value="file_or_uri">
+                <param name="source" argument="-f" type="text" label="file or uri" help="file or uri" />
+                <param name="target" argument="-t" type="text"  label="target file" help="target file. E.g 'ERR035229.fastq.gz' " />
+                <param name="validate_only" argument="-v" type="boolean" label="validate only to check a source URI is valid, don't download" help="validate only, don't download" optional='true'/>
+                <param name="download_type" argument="-d" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional='true'>
+                    <option value="fastq" selected="true">fastq</option>
+                    <option value="srr">SRA</option>
+                </param>
+            </when>
+            <when value="library">
+                <param name="library" argument="-l" type="text" label="library" help="library" />
+                <param name="output_directory" argument="-d" type="text" label="output directory" help="output directory" />
+                <param name="download_type" argument="-t" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional='true'>
+                    <option value="fastq" selected="true">fastq</option>
+                    <option value="srr">SRA</option>
+                </param>
+                <param name="sepe" argument="-n" type="select" label="SINGLE-end or PAIRED-end, default PAIRED" help="SINGLE-end or PAIRED-end, default PAIRED" optional='true'>
+                    <option value="PAIRED" selected="true">PAIRED</option>
+                    <option value="SINGLE">SINGLE</option>
+                </param>
+            </when>
+        </conditional>
+
         <param name="resource" argument="-s" type="select"  label="resource or directory, default 'auto' " help="How to fetch the file, e.g. there’s a specific method for getting results from the Human Cell Atlas' 'Azul' resource. " optional='true' >
             <option value="auto" selected="true">auto</option>
             <option value="ena">ENA</option>
@@ -56,30 +90,31 @@
         <param name="mode" argument="-p" type="select" label="public or private, default public. Private usable by EBI staff only" help="public or private, default 'public' " optional='true'>
             <option value="public" selected="true">public</option>
             <option value="private">private</option>
-            <option value="library_wise">library_wise</option>
-
 	    </param>
         <param name="library" argument="-l" type="text"  label="ENA library (ENA source files only), by default inferred from file name" help="library, by default inferred from file name. E.g. -l ERR1888646 " optional='true'/>
         <param name="config_file" argument="-c" type="data" format="atlas-fastq-provider-config.sh" label="config file to override defaults" help="config file to override defaults" optional='true'/>
-        <param name="validate_only" argument="-v" type="boolean" label="validate only to check a source URI is valid, don't download" help="validate only, don't download" optional='true'/>
-        <param name="download_type" argument="-d" type="select" label="download type, fastq or SRA file" help="download type, fastq or srr" optional='true'>
-            <option value="fastq" selected="true">fastq</option>
-            <option value="srr">SRA</option>
-	    </param>
+
     </inputs>
     <outputs>
         <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz"  />
     </outputs>
     <tests>
         <test expect_num_outputs="1">
+            <param name="main_source" value="file_or_uri"/>
             <param name="source" value="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR035/ERR035229/ERR035229.fastq.gz"/>
             <param name="target" value="ERR035229.fastq.gz"/>
             <output name="outfile"  md5="c9482e89552630084997112787a5d796" />   
         </test>
     </tests>
     <help><![CDATA[
-    
-        Usage: fetchFastq.sh [-f <file or uri>] [-t <target file>] [-s <source resource or directory, default 'auto'>] [-m <retrieval method, default 'auto'>] [-p <public or private, default 'public'>] [-l <library, by default inferred from file name>] [-c <config file to override defaults>] [-v <validate only, don't download>] [-d <download type, 'fastq' or 'srr'>]
+        
+        Usage (<file or uri>  as main source): 
+
+            fetchFastq.sh -f <file or uri> -t <target file> [-s <source resource or directory, default 'auto'>] [-m <retrieval method, default 'auto'>] [-p <public or private, default 'public'>] [-l <library, by default inferred from file name>] [-c <config file to override defaults>] [-v <validate only, don't download>] [-d <download type, 'fastq' or 'srr'>]
+        
+        Usage (<library> as main source): 
+
+            fetchEnaLibraryFastqs.sh -l <library> -d <output directory> [-m <retrieval method, default 'wget'>] [-s <source directory for method 'dir'>] [-p <public or private, default public>] [-c <config file to override defaults>] [-t <download type, fastq or srr>] [-n <SINGLE or PAIRED, default PAIRED>]
 
     ]]></help>
     <citations>

--- a/tools/fastq_provider/fastq_provider.xml
+++ b/tools/fastq_provider/fastq_provider.xml
@@ -105,26 +105,6 @@
         </param>
         <param name="config_file" argument="-c" type="data" format="text" label="Config file to override defaults" help="Config file to override defaults." optional="true"/>
     </inputs>
-
-<!--     <outputs>
-        <conditional name="main_source">
-            <when value="file_or_uri">
-                <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz" />
-            </when>
-            <when value="library">
-                <conditional name="sepe">
-                    <when value="SINGLE">
-                        <data name="outfile" label="${tool.name} on ${on_string}: compressed fastq file" format="fastqsanger.gz" />
-                    </when>
-                    <when value="PAIRED">
-                        <data name="outfile_1" label="${tool.name} on ${on_string}: compressed fastq file _1" format="fastqsanger.gz" />
-                        <data name="outfile_2" label="${tool.name} on ${on_string}: compressed fastq file _2" format="fastqsanger.gz" />
-                    </when>
-                </conditional>
-            </when>
-        </conditional>
-    </outputs> -->
-
     <outputs>
         <data name="dl_from_path" label="Downloaded from path" format="fastqsanger.gz" from_work_dir="dl_from_path.fastq.gz">
             <filter>fetch_type["script"] == "fetchFastq"</filter>
@@ -138,7 +118,6 @@
               <data name="dl_from_lib_pair_2" label="Downloaded library, pair read 2" format="fastqsanger.gz" from_work_dir="dl_from_lib_pair_2.fastq.gz"/>
         </collection>
     </outputs>
-
     <tests>
         <test>
             <param name="script" value="fetchFastq"/>
@@ -164,7 +143,6 @@
             </output_collection> 
         </test>
     </tests>
-
     <help><![CDATA[
         
         Usage (<file or uri>  as main source): 
@@ -176,9 +154,7 @@
             fetchEnaLibraryFastqs.sh -l <library> -d <output directory> [-m <retrieval method, default 'wget'>] [-s <source directory for method 'dir'>] [-p <public or private, default public>] [-c <config file to override defaults>] [-t <download type, fastq or srr>] [-n <SINGLE or PAIRED, default PAIRED>]
 
     ]]></help>
-
     <citations>
-
         <citation type="bibtex">
             @misc{githubatlas-fastq-provider,
             author = {Jonathan Manning, EBI Gene Expression Team},
@@ -188,8 +164,6 @@
             journal = {GitHub repository},
             url = {https://github.com/ebi-gene-expression-group/atlas-fastq-provider},
         }</citation>
-        
     </citations>
-
 </tool>
 


### PR DESCRIPTION
# Description

Make some refinements to the atlas-fastq-provider galaxy wrapper. ISL uses the library-wise downloader rather than file-wise, we need an extra option in the wrapper for that. 

Basically, the wrapper needs a library-wise logic that calls `fetchEnaLibraryFastqs.sh` (if library-name param is provided) or `fetchFastq.sh` (if filename param is provided). Depending on each case, specific set of parameters need to be displayed.

This PR is related to  https://github.com/ebi-gene-expression-group/atlas-fastq-provider/pull/17

---
Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [x] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
