### PR TITLE
Rename salmonKallistoMtxTo10x matrix input symlink so it is not the same as output

### DIFF
--- a/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
+++ b/tools/salmon-kallisto-mtx-to-10x/salmonKallistoMtxTo10x.xml
@@ -1,4 +1,4 @@
-<tool id="_salmon_kallisto_mtx_to_10x" name="salmonKallistoMtxTo10x" version="0.0.1+galaxy5" profile="18.01">
+<tool id="_salmon_kallisto_mtx_to_10x" name="salmonKallistoMtxTo10x" version="0.0.1+galaxy6" profile="18.01">
     <description>Transforms .mtx matrix and associated labels into a format compatible with tools expecting old-style 10X data</description>
     <requirements>
       <requirement type="package" version="1.4.1">scipy</requirement>
@@ -8,9 +8,9 @@
     <command detect_errors="exit_code"><![CDATA[
         file $mtx_file | grep 'gzip compressed' > /dev/null;
         if [ $? -eq 0 ]; then
-            matrixfile=matrix.mtx.gz;
+            matrixfile=matrix-in.mtx.gz;
         else
-            matrixfile=matrix.mtx;
+            matrixfile=matrix-in.mtx;
         fi;
         ln -s ${mtx_file} \$matrixfile;
         $__tool_directory__/salmonKallistoMtxTo10x.py --cell_prefix "${cell_prefix}" "\${matrixfile}" "${genes_file}" "${barcodes_file}" ./


### PR DESCRIPTION
# Description

Otherwise, the input is overwritten by the output.

Fixes #263.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
