### PR TITLE
add anndata2seurat conversion

### DIFF
--- a/tools/tertiary-analysis/sceasy/sceasy_convert.xml
+++ b/tools/tertiary-analysis/sceasy/sceasy_convert.xml
@@ -30,6 +30,10 @@
             -e 'srt <- readRDS("input.rds")'
             -e 'sceasy::convertFormat(srt, outFile="output.h5ad", from="seurat", to="anndata", assay="${conversion.assay}", main_layer="${conversion.dtype}")'
             -e 'print(srt)'
+#else if $conversion.direction == "anndata2seurat"
+            -e 'srt <- sceasy::convertFormat("input.h5ad", from="anndata", to="seurat", main_layer="${conversion.assay}")'
+            -e 'saveRDS(srt, "output.rds")'
+            -e 'print(srt)'
 #end if
 ]]></command>
 
@@ -74,6 +78,14 @@
           <option value="scale.data">scale.data</option>
         </param>
       </when>
+      <when value="anndata2seurat">
+        <param name="input_object_file" type="data" format="h5ad" label="Input object in AnnData format"/>
+        <param name="assay" type="text" value="RNA" label="Name of assay in Seurat object to store expression values" help="Please make sure the assay exists"/>
+          <option value="counts" selected="true">counts</option>
+          <option value="logcounts">logcounts</option>
+          <option value="cpm">cpm</option>
+        </param>
+      </when>
     </conditional>
   </inputs>
 
@@ -86,6 +98,9 @@
     </data>
     <data name="output_anndata" format="h5" from_work_dir="output.h5ad" label="${tool.name} on ${on_string}: AnnData">
       <filter>conversion['direction'].endswith('anndata')</filter>
+    </data>
+    <data name="output_seurat" format="rdata" from_work_dir="output.rds" label="${tool.name} on ${on_string}: Seurat">
+      <filter>conversion['direction'].endswith('seurat')</filter>
     </data>
   </outputs>
 
@@ -105,7 +120,7 @@ Convert scRNA data object between formats `sceasy::convertFormat()`
 Support the following conversion:
  * Loom <-> SingleCellExperiment (full)
  * SingleCellExperiment -> AnnData (matrix, metadata, reducedDim)
- * Seurat -> AnnData (matrix, metadata, reducedDim)
+ * Seurat <-> AnnData (matrix, metadata, reducedDim)
 
 @HELP@
 


### PR DESCRIPTION
# Description

Based on the code from https://github.com/cellgeni/sceasy/blob/master/R/functions.R I tried to adapt it to SCEasy in order to allow Galaxy users to convert AnnData to Seurat files. I find it more useful to expand the SCEasy tool rather than to create a new one. It might be also possible to incorporate AnnData to CDS object conversion within SCEasy, once my pull request fixing the bug in the source code is approved. 

Fixes # (issue)
If the changed code works, it will fix the issue #225 (SCEasy - AnnData-->Seurat)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)