### PR TITLE
Update scanpy_macros2.xml and tools to avoid sorting issues

### DIFF
--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -1,9 +1,10 @@
 <macros>
-  <token name="@TOOL_VERSION@">1.8.1+3</token>
+  <token name="@TOOL_VERSION@">1.8.1</token>
   <token name="@HELP@">More information can be found at https://scanpy.readthedocs.io</token>
   <token name="@PROFILE@">18.01</token>
   <token name="@VERSION_HISTORY@"><![CDATA[
 **Version history**
+1.8.1+galaxy4: Simply fixes version label to get versions sorted properly on Galaxy.
 
 1.8.1+3+galaxy0: Upate to scanpy-scripts 1.1.3 (running scanpy ==1.8.1), including a fix to MTX output and a bugfix for the Scrublet wrapper.
 


### PR DESCRIPTION
# Description

Unfortunately latest version label changes introduce this issue:

![image](https://user-images.githubusercontent.com/368478/186622195-4cb628c0-3f92-4bcf-ae4f-8a986aa6b566.png)

To fix this we need to move back tools to list versions as `<tool-version>+galaxy<number>` with no `+` inside the tool-version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
