### PR TITLE
Correct method in the tool description

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,10 +63,14 @@ jobs:
     - name: Install Planemo
       run: pip install planemo
     - name: Fake a Planemo run to update cache
-      if: steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true'
-      run: |
-        echo "<tool> </tool> " > tool.xml
-        PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_source https://github.com/${{ env.GALAXY_FORK }}/galaxy --galaxy_branch ${{ env.GALAXY_BRANCH }} tool.xml
+      uses: galaxyproject/planemo-ci-action@v1
+      id: discover
+      with:
+        create-cache: ${{ steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true' }}
+        galaxy-fork: ${{ env.GALAXY_FORK }}
+        galaxy-branch: ${{ env.GALAXY_BRANCH }}
+        max-chunks: ${{ env.MAX_CHUNKS }}
+        python-version: ${{ matrix.python-version }}
 
   find_changed:
     name: Determine changed repositories

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -66,7 +66,7 @@ jobs:
       if: steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true'
       run: |
         echo "<tool " > tool.xml
-        PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_source $GALAXY_REPO --galaxy_branch $GALAXY_RELEASE tool.xml
+        PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_source https://github.com/${{ env.GALAXY_FORK }}/galaxy --galaxy_branch ${{ env.GALAXY_BRANCH }} tool.xml
 
   find_changed:
     name: Determine changed repositories

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,8 +6,8 @@ on:
       - develop
 
 env:
-  GALAXY_REPO: https://github.com/galaxyproject/galaxy
-  GALAXY_RELEASE: release_20.09
+  GALAXY_FORK: galaxyproject
+  GALAXY_BRANCH: release_21.01
   MAX_CHUNKS: 4
 
 jobs:
@@ -43,7 +43,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Determine latest commit in the Galaxy repo
       id: get-galaxy-sha
-      run: echo "::set-output name=galaxy_head_sha::$(git ls-remote ${{ env.GALAXY_REPO }} refs/heads/${{ env.GALAXY_RELEASE }} | cut -f1)"
+      run: echo "::set-output name=galaxy_head_sha::$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)"
     - name: Cache .cache/pip
       uses: actions/cache@v2
       id: cache-pip

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,7 +65,7 @@ jobs:
     - name: Fake a Planemo run to update cache
       if: steps.cache-pip.outputs.cache-hit != 'true' || steps.cache-planemo.outputs.cache-hit != 'true'
       run: |
-        echo "<tool " > tool.xml
+        echo "<tool> </tool> " > tool.xml
         PIP_QUIET=1 planemo test --galaxy_python_version ${{ matrix.python-version }} --no_conda_auto_init --galaxy_source https://github.com/${{ env.GALAXY_FORK }}/galaxy --galaxy_branch ${{ env.GALAXY_BRANCH }} tool.xml
 
   find_changed:

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -132,7 +132,7 @@ Compute a neighborhood graph of observations (`pp.neighbors`)
 
 The neighbor search efficiency of this heavily relies on UMAP (McInnes et al, 2018),
 which also provides a method for estimating connectivities of data points -
-the connectivity of the manifold (`method=='umap'`). If `method=='diffmap'`,
+the connectivity of the manifold (`method=='umap'`). If `method=='Gaussian'`,
 connectivities are computed according to Coifman et al (2005), in the adaption of
 Haghverdi et al (2016).
 


### PR DESCRIPTION
The method should be Gaussian not diffmap (this isn't a method, it's one of the embeddings you can use) - see the documentation on the Scanpy pp.neighbours https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.neighbors.html - which confirms that the method used in the cited papers is gauss/gaussian.  This really confused me so it would be good to change it to prevent anyone else trying to work out why the diffmap doesn't exist as a method on the tool!
Hopefully this is an easy change as it only affects the instructions. 

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`)  
