### PR TITLE
Anndata layer swap and markers

### DIFF
--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -104,6 +104,14 @@ adata.obs = add_cell_metadata(adata)
 adata.raw = adata
 #end if
 
+#if $swap_layer_to_x.default:
+#if $swap_layer_to_x.new_name_x:
+adata.layers['${swap_layer_to_x.new_name_x}'] = adata.X
+#end if
+adata.X = adata.layers['${swap_layer_to_x.layer}']
+del adata.layers['${swap_layer_to_x.layer}']
+#end if
+
 gene_name = '${gene_symbols_field}'
 qc_vars = list()
 

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -50,6 +50,7 @@ python $operations
   <configfiles>
     <configfile name="operations">
 import gc
+from os import makedirs
 import scanpy as sc
 import anndata
 from numpy import all
@@ -294,7 +295,23 @@ if 'n_cells' not in adata.var.columns:
 if 'n_counts' not in adata.var.columns:
     sc.pp.filter_genes(adata, min_counts=0)
 
+#if not $split_on_obs.default or $split_on_obs.output_main:
 adata.write('output.h5', compression='gzip')
+#end if
+
+#if $split_on_obs.default:
+s = 0
+res_dir = "output_split"
+makedirs(res_dir, exist_ok=True)
+for field_value in adata.obs["${split_on_obs.key}"].unique():
+    ad_s = adata[adata.obs.${split_on_obs.key} == field_value]
+    ad_s.write(f"{res_dir}/${split_on_obs.key}_{s}.h5", compression='gzip')
+    if s > 0:
+        gc.collect()
+    s += 1
+#end if
+
+
     </configfile>
 </configfiles>
 
@@ -403,10 +420,27 @@ adata.write('output.h5', compression='gzip')
       </when>
     </conditional>
     <param name="sanitize_varm" type="boolean" checked="false" label="Sanitise any null raw.varm objects if any" help="This might be relevant for interfacing with newer versions of AnnData, that might complain if .raw includes a varm null object."/>
+    <conditional name="split_on_obs">
+      <param name="default" type="boolean" checked="false" label="Split on obs" help="Split the AnnData object into multiple AnnData objects based on the values of a given obs key. This is useful for example to split a dataset based on a cluster annotation."/>
+      <when value="true">
+        <param name="key" type="text" label="Obs key to split on" help="The obs key to split on. For example, if you want to split on cluster annotation, you can use the key 'louvain'."/>
+        <param name="output_main" type="boolean" checked="true" label="Output main AnnData object" help="If checked, the main AnnData object will be outputted as well."/>
+      </when>
+      <when value="false"/>
+    </conditional>
   </inputs>
 
   <outputs>
-    <expand macro="output_data_obj_no_loom" description="metadata changes on"/>
+    <data name="output_h5ad" format="h5ad" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData">
+      <filter>output_format == 'anndata_h5ad' and (('output_main' in split_on_obs and split_on_obs['output_main']) or (not split_on_obs['default']))</filter>
+    </data>
+    <data name="output_h5" format="h5" from_work_dir="output.h5" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData (h5)">
+      <filter>output_format == 'anndata' and (('output_main' in split_on_obs and split_on_obs['output_main']) or (not split_on_obs['default']))</filter>
+    </data>
+    <collection name="output_h5ad_split" type="list" label="${tool.name} on ${on_string}: @DESCRIPTION@ AnnData split">
+      <discover_datasets pattern="(?P&lt;designation&gt;.+)\.h5" directory="output_split" format="h5ad" visible="true"/>
+      <filter>split_on_obs['default']</filter>
+    </collection>
   </outputs>
 
   <tests>
@@ -512,6 +546,26 @@ adata.write('output.h5', compression='gzip')
           <has_h5_keys keys="layers/filtered" />
         </assert_contents>
       </output>
+    </test>
+    <test>
+      <param name="input_obj_file" value="find_cluster.h5"/>
+      <conditional name="split_on_obs">
+        <param name="default" value="true"/>
+        <param name="key" value="louvain"/>
+        <param name="output_main" value="true"/>
+      </conditional>
+      <output name="output_h5ad" ftype="h5ad">
+        <assert_contents>
+          <has_h5_keys keys="obs/louvain" />
+        </assert_contents>
+      </output>
+      <output_collection name="output_h5ad_split" type="list" count="5">
+        <element name="louvain_0" ftype="h5ad">
+          <assert_contents>
+            <has_h5_keys keys="obs/louvain" />
+          </assert_contents>
+        </element>
+      </output_collection>
     </test>
   </tests>
 

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -415,7 +415,7 @@ adata.write('output.h5', compression='gzip')
       </conditional>
       <output name="output_h5ad" ftype="h5ad">
         <assert_contents>
-          <has_h5_keys keys="layer/X_old" />
+          <has_h5_keys keys="layers/X_old" />
         </assert_contents>
       </output>
     </test>

--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy91" profile="@PROFILE@">
+<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy92" profile="@PROFILE@">
   <description>modifies metadata and flags genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -61,9 +61,9 @@ def make_column_values_unique(df, field, new_field=None, suffix = '-duplicate-')
   appendents = (suffix + df.groupby(field).cumcount().astype(str).replace('0','')).replace(suffix, '')
   df[new_field] = df[field].astype(str) + appendents.astype(str)
   return df
-	    
-adata = sc.read('input.h5')
 
+adata = sc.read('input.h5')
+	    
 #if $add_cell_metadata.default:
 import pandas as pd
 
@@ -96,7 +96,7 @@ def add_cell_metadata(ad, metadata_file="cell_metadata.tsv", drop_duplicates=Tru
               print(f"Changing {col} from {merged_obs[col].dtype} to {prev_dtype}")
               merged_obs[col] = merged_obs[col].astype(prev_dtype)
   return merged_obs
-	    
+
 adata.obs = add_cell_metadata(adata)
 #end if
 
@@ -293,6 +293,14 @@ adata.write('output.h5', compression='gzip')
   <inputs>
     <param name="input_obj_file" argument="input-object-file" type="data" format="h5,h5ad" label="Input object in hdf5 AnnData format"/>
     <expand macro="output_object_params_no_loom"/>
+    <conditional name="swap_layer_to_x">
+      <param name="default" type="boolean" checked="false" label="Swap layer to X"/>
+      <when value="true">
+        <param name="layer" type="text" value="" label="Name of layer to swap to X" help="This layer name needs to exist within ad.layers or this will fail."/>
+        <param name="new_name_x" type="text" value="old_X" label="Name of the new slot for X within layers" help="Leave empty and the old X will be lost."/>
+      </when>
+      <when value="false"/>
+    </conditional>
     <conditional name="add_cell_metadata">
       <param name="default" type="boolean" checked="false" label="Merge additional cell metadata"/>
       <when value="true">
@@ -397,6 +405,19 @@ adata.write('output.h5', compression='gzip')
     <test>
       <param name="input_obj_file" value="find_cluster.h5"/>
       <output name="output_h5ad" file="anndata_ops.h5" ftype="h5ad" compare="sim_size"/>
+    </test>
+    <test>
+      <param name="input_obj_file" value="mnn.h5"/>
+      <conditional name="swap_layer_to_x">
+        <param name="default" value="true"/>
+        <param name="layer" value="mnn"/>
+        <param name="new_name_x" value="X_old"/>
+      </conditional>
+      <output name="output_h5ad" ftype="h5ad">
+        <assert_contents>
+          <has_h5_keys keys="layer/X_old" />
+        </assert_contents>
+      </output>
     </test>
     <test>
       <param name="input_obj_file" value="anndata_ops.h5"/>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
@@ -67,10 +67,12 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
           <option value="logreg">logistic regression</option>
         </param>
         <param name="use_raw" type="boolean" truevalue="--use-raw" falsevalue="--no-raw" checked="true"
-               label="Use raw attribute if present. If the layer option is set, this will be ignored (raw will not be used)."/>
+               label="Use raw attribute if present" help="Uses adata.raw, usually what was available before processing. If the layer option is set, this will be ignored (raw will not be used)."/>
         <param name="rankby_abs" argument="--rankby_abs" type="boolean" truevalue="--rankby-abs" falsevalue="" checked="false"
                label="Rank by absolute value of the scores instead of the scores"/>
-        <param name="groups" argument="--groups" optional="true" type="text" label="Subset of groups/clusters to which comparisons shell be restricted. Currently it fails if a single group is given, provide at least two."/>
+        <param name="groups" argument="--groups" optional="true" type="text"
+               label="Subset of groups/clusters to which comparisons should be restricted" 
+               help="Comma separated list of groups existing within the groupby field in obs. Currently it fails if a single group is given, provide at least two."/>
         <param name="reference" argument="--reference" type="text" value="rest" label="If 'rest', compare to the union of the rest of the group/cluster. If a group identifier, compare to that group"/>
         <conditional name="filter">
           <param name="default" type="boolean" checked="false" label="Use filtering defaults"/>
@@ -84,7 +86,8 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
                    help="Post-test filtering to only keep genes with at least this fold change of expression relative to the reference group."/>
           </when>
         </conditional>
-        <param name="layer" argument="--layer" type="text" optional="true" label="Layer to use marker genes, leave empty of .X . It will override the use of raw if set."/>
+        <param name="layer" argument="--layer" type="text" optional="true" label="Layer to use for marker genes computation" 
+                help="The method prefers matrices/layers that are logged. Leave empty to use the default .X matrix. It will override the use of raw if set."/>
         <param name="pts" argument="--pts"  type="boolean" checked="false" label="Compute the fraction of cells expressing the genes?" truevalue="--pts" falsevalue="" />
         <param name="tie_correct" argument="--tie-correct"  type="boolean" checked="false" label="Use tie correction for 'wilcoxon' scores. Used only for 'wilcoxon'." truevalue="--tie-correct" falsevalue=""/>
       </when>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_markers" name="Scanpy FindMarkers" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_find_markers" name="Scanpy FindMarkers" version="@TOOL_VERSION@+galaxy91" profile="@PROFILE@">
   <description>to find differentially expressed genes between groups</description>
   <macros>
     <import>scanpy_macros2.xml</import>
@@ -35,6 +35,9 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
     #if $settings.filter.default == "false"
       --filter-params 'min_in_group_fraction:${settings.filter.min_in_group_fraction},max_out_group_fraction:${settings.filter.max_out_group_fraction},min_fold_change:${settings.filter.min_fold_change}'
     #end if
+    #if $settings.layer
+        --layer '${settings.layer}'
+    #end if
     $settings.pts $settings.tie_correct
     #end if
     @INPUT_OPTS@
@@ -58,14 +61,14 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
         <param name="method" argument="--method" type="select" label="Method for testing differentially expressed genes">
           <option value="t-test_overestim_var" selected="true">t-test with over-estimated variance</option>
           <option value="t-test">t-test</option>
-          <option value="wilcoxon">wilcoxon test, currently broken don't use</option>
+          <option value="wilcoxon">wilcoxon test</option>
           <option value="logreg">logistic regression</option>
         </param>
         <param name="use_raw" type="boolean" truevalue="--use-raw" falsevalue="--no-raw" checked="true"
-               label="Use raw attribute if present"/>
+               label="Use raw attribute if present. Make sure to turn off if using the 'layer' option, or to make sure that that layer is present in raw."/>
         <param name="rankby_abs" argument="--rankby_abs" type="boolean" truevalue="--rankby-abs" falsevalue="" checked="false"
                label="Rank by absolute value of the scores instead of the scores"/>
-        <param name="groups" argument="--groups" optional="true" type="text" label="Subset of groups/clusters to which comparisons shell be restricted."/>
+        <param name="groups" argument="--groups" optional="true" type="text" label="Subset of groups/clusters to which comparisons shell be restricted. Currently it fails if a single group is given, provide at least two."/>
         <param name="reference" argument="--reference" type="text" value="rest" label="If 'rest', compare to the union of the rest of the group/cluster. If a group identifier, compare to that group"/>
         <conditional name="filter">
           <param name="default" type="boolean" checked="false" label="Use filtering defaults"/>
@@ -79,6 +82,7 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
                    help="Post-test filtering to only keep genes with at least this fold change of expression relative to the reference group."/>
           </when>
         </conditional>
+        <param name="layer" argument="--layer" type="text" optional="true" label="Layer to use marker genes, leave empty of .X . Most likely should not be used with use-raw."/>
         <param name="pts" argument="--pts"  type="boolean" checked="false" label="Compute the fraction of cells expressing the genes?" truevalue="--pts" falsevalue="" />
         <param name="tie_correct" argument="--tie-correct"  type="boolean" checked="false" label="Use tie correction for 'wilcoxon' scores. Used only for 'wilcoxon'." truevalue="--tie-correct" falsevalue=""/>
       </when>
@@ -119,6 +123,24 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
       <param name="method" value="t-test_overestim_var"/>
       <param name="rankby_abs" value="false"/>
       <output name="output_tsv" file="diffexp.tsv" ftype="tabular" compare="sim_size"/>
+    </test>
+    <test>
+      <param name="input_obj_file" value="mnn"/>
+      <param name="input_format" value="anndata"/>
+      <param name="output_format" value="no_matrix_output"/>
+      <param name="n_genes" value="50"/>
+      <param name="output_markers" value="true"/>
+      <param name="default" value="false"/>
+      <param name="groupby" value="louvain"/>
+      <param name="key_added" value="l_markers"/>
+      <param name="method" value="wilcoxon"/>
+      <param name="layer" value="mnn"/>
+      <output name="output_tsv" ftype="tabular">
+        <assert_contents>
+          <has_text text="cluster" />
+          <has_n_lines n="50" />
+        </assert_contents>
+      </output>
     </test>
   </tests>
 

--- a/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
@@ -26,7 +26,6 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
         --key-added '${key_added}'
     #end if
     --method '${settings.method}'
-    ${settings.use_raw}
     ${settings.rankby_abs}
     #if $settings.groups
         --groups '${settings.groups}'
@@ -37,6 +36,9 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
     #end if
     #if $settings.layer
         --layer '${settings.layer}'
+        --no-raw
+    #else
+        ${settings.use_raw}
     #end if
     $settings.pts $settings.tie_correct
     #end if
@@ -65,7 +67,7 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
           <option value="logreg">logistic regression</option>
         </param>
         <param name="use_raw" type="boolean" truevalue="--use-raw" falsevalue="--no-raw" checked="true"
-               label="Use raw attribute if present. Make sure to turn off if using the 'layer' option, or to make sure that that layer is present in raw."/>
+               label="Use raw attribute if present. If the layer option is set, this will be ignored (raw will not be used)."/>
         <param name="rankby_abs" argument="--rankby_abs" type="boolean" truevalue="--rankby-abs" falsevalue="" checked="false"
                label="Rank by absolute value of the scores instead of the scores"/>
         <param name="groups" argument="--groups" optional="true" type="text" label="Subset of groups/clusters to which comparisons shell be restricted. Currently it fails if a single group is given, provide at least two."/>
@@ -82,7 +84,7 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
                    help="Post-test filtering to only keep genes with at least this fold change of expression relative to the reference group."/>
           </when>
         </conditional>
-        <param name="layer" argument="--layer" type="text" optional="true" label="Layer to use marker genes, leave empty of .X . Most likely should not be used with use-raw."/>
+        <param name="layer" argument="--layer" type="text" optional="true" label="Layer to use marker genes, leave empty of .X . It will override the use of raw if set."/>
         <param name="pts" argument="--pts"  type="boolean" checked="false" label="Compute the fraction of cells expressing the genes?" truevalue="--pts" falsevalue="" />
         <param name="tie_correct" argument="--tie-correct"  type="boolean" checked="false" label="Use tie correction for 'wilcoxon' scores. Used only for 'wilcoxon'." truevalue="--tie-correct" falsevalue=""/>
       </when>
@@ -125,9 +127,8 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
       <output name="output_tsv" file="diffexp.tsv" ftype="tabular" compare="sim_size"/>
     </test>
     <test>
-      <param name="input_obj_file" value="mnn"/>
+      <param name="input_obj_file" value="mnn.h5"/>
       <param name="input_format" value="anndata"/>
-      <param name="output_format" value="no_matrix_output"/>
       <param name="n_genes" value="50"/>
       <param name="output_markers" value="true"/>
       <param name="default" value="false"/>
@@ -135,10 +136,9 @@ PYTHONIOENCODING=utf-8 scanpy-find-markers
       <param name="key_added" value="l_markers"/>
       <param name="method" value="wilcoxon"/>
       <param name="layer" value="mnn"/>
-      <output name="output_tsv" ftype="tabular">
+      <output name="output_h5ad" ftype="h5ad">
         <assert_contents>
-          <has_text text="cluster" />
-          <has_n_lines n="50" />
+          <has_h5_keys keys="uns/l_markers_mnn"/>
         </assert_contents>
       </output>
     </test>


### PR DESCRIPTION
# Description

- Adds the ability to choose layer for marker genes.
- Warns user that groups in layers needs to use at least two groups.
- Allow to swap layers into X with AnnData operations.
- Tests for these operations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [x] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
