### PR TITLE
Detects OOM for CellBrowser even if tool exits with 0 code.

### DIFF
--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -1,4 +1,4 @@
-<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="1.0.0+galaxy0" profile="18.01">
+<tool id="ucsc_cell_browser" name="UCSC Cell Browser" version="1.0.0+galaxy1" profile="18.01">
   <description>displays single-cell clusterized data in an interactive web application.</description>
   <requirements>
     <requirement type="package" version="1.0.0">ucsc-cell-browser</requirement>

--- a/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
+++ b/tools/tertiary-analysis/ucsc-cell-browser/cell-browser.xml
@@ -5,6 +5,7 @@
   </requirements>
 <stdio>
 <exit_code range="1:" />
+<regex source="both" match="Killed" level="fatal_oom" description="Killed, most likely due to OOM" />
 </stdio>
 <command><![CDATA[
 #if $input_type.expression_source == "native-cell-browser":

--- a/tools/tertiary-analysis/ucsc-cell-browser/get_test_data.sh
+++ b/tools/tertiary-analysis/ucsc-cell-browser/get_test_data.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/E-MTAB-6077/E-MTAB-6077.project.h5ad
+mkdir -p test-data
 mv E-MTAB-6077.project.h5ad test-data/


### PR DESCRIPTION
# Description

cbScanpyImport, part of UCSC CellBrowser, exists with code 0 (no error) on Out of memory kill signal. This handles the process more gracefully so that Galaxy can understand it actually failed and needs to be resubmitted.

Handles https://github.com/maximilianh/cellBrowser/issues/263 (at least in the Kubernetes case)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [x] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
