### PR TITLE
Use tabular instead of CSV

### DIFF
--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -58,15 +58,15 @@ def write_DESeq2_inputs(pdata, layer=None, output_dir="", factor_fields=None):
     # avoid dash that is read as point on R colnames.
     obs_for_deseq.index = obs_for_deseq.index.str.replace("-", "_")
     obs_for_deseq.index = obs_for_deseq.index.str.replace(" ", "_")
-    col_metadata_file = f"{output_dir}col_metadata.csv"
+    col_metadata_file = f"{output_dir}col_metadata.tsv"
     # write obs to a col_metadata file
     if factor_fields:
         # only output the index plus the columns in factor_fields in that order
-        obs_for_deseq[factor_fields].to_csv(col_metadata_file, sep=",", index=True)
+        obs_for_deseq[factor_fields].to_csv(col_metadata_file, sep="\t", index=True)
     else:
-        obs_for_deseq.to_csv(col_metadata_file, sep=",", index=True)
+        obs_for_deseq.to_csv(col_metadata_file, sep="\t", index=True)
     # write var to a gene_metadata file
-    pdata.var.to_csv(f"{output_dir}gene_metadata.csv", sep=",", index=True)
+    pdata.var.to_csv(f"{output_dir}gene_metadata.tsv", sep=",", index=True)
     # write the counts matrix of a specified layer to file
     if layer is None:
         # write the X numpy matrix transposed to file
@@ -75,7 +75,7 @@ def write_DESeq2_inputs(pdata, layer=None, output_dir="", factor_fields=None):
         df = pd.DataFrame(
             pdata.layers[layer].T, index=pdata.var.index, columns=obs_for_deseq.index
         )
-    df.to_csv(f"{output_dir}counts_matrix.csv", sep=",", index_label="")
+    df.to_csv(f"{output_dir}counts_matrix.tsv", sep="\t", index_label="")
 
 
 def plot_pseudobulk_samples(

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -1,4 +1,4 @@
-<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy0" profile="20.05">
+<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy1" profile="20.05">
     <description>aggregates single cell RNA-seq data for running bulk RNA-seq methods</description>
     <requirements>
         <requirement type="package" version="1.4.0">decoupler</requirement>
@@ -74,9 +74,9 @@ python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
         <data name="pbulk_anndata" format="h5ad" label="${tool.name} on ${on_string}: Pseudo-bulk AnnData">
             <filter>produce_anndata</filter>
         </data>
-        <data name="count_matrix" format="csv" label="${tool.name} on ${on_string}: Count Matrix" from_work_dir="deseq_output_dir/counts_matrix.csv"/>
-        <data name="samples_metadata" format="csv" label="${tool.name} on ${on_string}: Samples Metadata (factors file)" from_work_dir="deseq_output_dir/col_metadata.csv"/>
-        <data name="genes_metadata" format="csv" label="${tool.name} on ${on_string}: Genes Metadata" from_work_dir="deseq_output_dir/gene_metadata.csv"/>
+        <data name="count_matrix" format="tabular" label="${tool.name} on ${on_string}: Count Matrix" from_work_dir="deseq_output_dir/counts_matrix.tsv"/>
+        <data name="samples_metadata" format="tabular" label="${tool.name} on ${on_string}: Samples Metadata (factors file)" from_work_dir="deseq_output_dir/col_metadata.tsv"/>
+        <data name="genes_metadata" format="tabular" label="${tool.name} on ${on_string}: Genes Metadata" from_work_dir="deseq_output_dir/gene_metadata.tsv"/>
         <data name="plot_output" format="png" label="${tool.name} on ${on_string}: Pseudobulk plot" from_work_dir="plots_output_dir/pseudobulk_samples.png">
             <filter>produce_plots</filter>
         </data>
@@ -105,17 +105,17 @@ python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
                     <has_h5_keys keys="obs/psbulk_n_cells"/>
                 </assert_contents>
             </output>
-            <output name="count_matrix" ftype="csv">
+            <output name="count_matrix" ftype="tabular">
                 <assert_contents>
                     <has_n_lines n="3620"/>
                 </assert_contents>
             </output>
-            <output name="samples_metadata" ftype="csv">
+            <output name="samples_metadata" ftype="tabular">
                 <assert_contents>
                     <has_n_lines n="8"/>
                 </assert_contents>
             </output>
-            <output name="genes_metadata" ftype="csv">
+            <output name="genes_metadata" ftype="tabular">
                 <assert_contents>
                     <has_n_lines n="3620"/>
                 </assert_contents>
@@ -153,9 +153,11 @@ python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
 
         The tool will output the filtered AnnData, count matrix, samples metadata, genes metadata (in DESeq2 format), and the pseudobulk plot and filter by expression plot (if enabled).
 
+        You can obtain more information about Decoupler pseudobulk at the developers documentation `here <https://decoupler-py.readthedocs.io/en/latest/notebooks/pseudobulk.html>`_ .
+
         ]]>
     </help>
     <citations>
-        <citation type="doi">doi.org/10.1093/bioadv/vbac016</citation>
+        <citation type="doi">10.1093/bioadv/vbac016</citation>
     </citations>
 </tool>


### PR DESCRIPTION
# Description

The CSV files are not well handled when passed to EdgeR, so it is better to move everything to tabular instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
