### PR TITLE
Move to scanpy-scripts 1.1.6 bumping all +galaxy

### DIFF
--- a/tools/tertiary-analysis/scanpy/anndata_operations.xml
+++ b/tools/tertiary-analysis/scanpy/anndata_operations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy92" profile="@PROFILE@">
+<tool id="anndata_ops" name="AnnData Operations" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>modifies metadata and flags genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-cells.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_filter_cells" name="Scanpy FilterCells" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@" >
+<tool id="scanpy_filter_cells" name="Scanpy FilterCells" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@" >
   <description>based on counts and numbers of genes expressed</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-filter-genes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_filter_genes" name="Scanpy FilterGenes" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_filter_genes" name="Scanpy FilterGenes" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>based on counts and numbers of cells expressed</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-cluster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_cluster" name="Scanpy FindCluster" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_find_cluster" name="Scanpy FindCluster" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>based on community detection on KNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-markers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_markers" name="Scanpy FindMarkers" version="@TOOL_VERSION@+galaxy91" profile="@PROFILE@">
+<tool id="scanpy_find_markers" name="Scanpy FindMarkers" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>to find differentially expressed genes between groups</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-find-variable-genes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_find_variable_genes" name="Scanpy FindVariableGenes" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_find_variable_genes" name="Scanpy FindVariableGenes" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>based on normalised dispersion of expression</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-integrate-bbknn.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-integrate-bbknn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_integrate_bbknn" name="Scanpy BBKNN" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_integrate_bbknn" name="Scanpy BBKNN" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>batch-balanced K-nearest neighbours</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-integrate-combat.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-integrate-combat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_integrate_combat" name="Scanpy ComBat" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_integrate_combat" name="Scanpy ComBat" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>adjust expression for variables that might introduce batch effect</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-integrate-harmony.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-integrate-harmony.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_integrate_harmony" name="Scanpy Harmony" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_integrate_harmony" name="Scanpy Harmony" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>adjust principal components for variables that might introduce batch effect</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-integrate-mnn.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-integrate-mnn.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_integrate_mnn" name="Scanpy MNN" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_integrate_mnn" name="Scanpy MNN" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>correct batch effects by matching mutual nearest neighbors</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-multiplet-scrublet-plot.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-multiplet-scrublet-plot.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_plot_scrublet" name="Scanpy Plot Scrublet" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_plot_scrublet" name="Scanpy Plot Scrublet" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>visualise multiplet scoring distribution</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-multiplet-scrublet.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-multiplet-scrublet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_multiplet_scrublet" name="Scanpy Scrublet" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_multiplet_scrublet" name="Scanpy Scrublet" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>remove multiplets from annData objects with Scrublet</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-neighbours.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_compute_graph" name="Scanpy ComputeGraph" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>to derive kNN graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-normalise-data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_normalise_data" name="Scanpy NormaliseData" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_normalise_data" name="Scanpy NormaliseData" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>to make all cells having the same total expression</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-embedding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_plot_embed" name="Scanpy PlotEmbed" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_plot_embed" name="Scanpy PlotEmbed" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>visualise cell embeddings</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-plot-trajectory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_plot_trajectory" name="Scanpy PlotTrajectory" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_plot_trajectory" name="Scanpy PlotTrajectory" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>visualise cell trajectories</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-read-10x.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_read_10x" name="Scanpy Read10x" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_read_10x" name="Scanpy Read10x" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>into hdf5 object handled by scanpy</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-regress-variable.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-regress-variable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_regress_variable" name="Scanpy RegressOut" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_regress_variable" name="Scanpy RegressOut" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>variables that might introduce batch effect</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-diffmap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_diffmap" name="Scanpy DiffusionMap" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_run_diffmap" name="Scanpy DiffusionMap" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>calculate diffusion components</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-dpt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_dpt" name="Scanpy DPT" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_run_dpt" name="Scanpy DPT" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>diffusion pseudotime inference</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-fdg.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-fdg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_fdg" name="Scanpy RunFDG" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_run_fdg" name="Scanpy RunFDG" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>visualise cell clusters using force-directed graph</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-paga.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_paga" name="Scanpy PAGA" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_run_paga" name="Scanpy PAGA" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>trajectory inference</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-pca.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_pca" name="Scanpy RunPCA" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_run_pca" name="Scanpy RunPCA" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>for dimensionality reduction</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-tsne.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_run_tsne" name="Scanpy RunTSNE" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>visualise cell clusters using tSNE</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-run-umap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_run_umap" name="Scanpy RunUMAP" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_run_umap" name="Scanpy RunUMAP" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>visualise cell clusters using UMAP</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy-scale-data.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy-scale-data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<tool id="scanpy_scale_data" name="Scanpy ScaleData" version="@TOOL_VERSION@+galaxy9" profile="@PROFILE@">
+<tool id="scanpy_scale_data" name="Scanpy ScaleData" version="@TOOL_VERSION@+galaxy93" profile="@PROFILE@">
   <description>to make expression variance the same for all genes</description>
   <macros>
     <import>scanpy_macros2.xml</import>

--- a/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
+++ b/tools/tertiary-analysis/scanpy/scanpy_macros2.xml
@@ -69,7 +69,7 @@ EMBL-EBI https://www.ebi.ac.uk/ and Teichmann Lab at Wellcome Sanger Institute.
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="1.1.3">scanpy-scripts</requirement>
+      <requirement type="package" version="1.1.6">scanpy-scripts</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
# Description

Moves all scanpy wrappers to scanpy scripts 1.1.6.

Fixes #242 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
