### PR TITLE
Decoupler: allow multiple merges on AnnData

### DIFF
--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -165,9 +165,11 @@ def main(args):
 
     # Merge adata.obs fields specified in args.adata_obs_fields_to_merge
     if args.adata_obs_fields_to_merge:
-        fields = args.adata_obs_fields_to_merge.split(",")
-        check_fields(fields, adata)
-        adata = merge_adata_obs_fields(fields, adata)
+        # first split potential groups by ";" and iterate over them
+        for group in args.adata_obs_fields_to_merge.split(";"):
+            fields = group.split(",")
+            check_fields(fields, adata)
+            adata = merge_adata_obs_fields(fields, adata)
 
     check_fields([args.groupby, args.sample_key], adata)
 
@@ -274,7 +276,7 @@ if __name__ == "__main__":
         "-m",
         "--adata_obs_fields_to_merge",
         type=str,
-        help="Fields in adata.obs to merge, comma separated",
+        help="Fields in adata.obs to merge, comma separated. You can have more than one set of fields, separated by semi-colon ;",
     )
     parser.add_argument(
         "--groupby",

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -165,8 +165,8 @@ def main(args):
 
     # Merge adata.obs fields specified in args.adata_obs_fields_to_merge
     if args.adata_obs_fields_to_merge:
-        # first split potential groups by ";" and iterate over them
-        for group in args.adata_obs_fields_to_merge.split(";"):
+        # first split potential groups by ":" and iterate over them
+        for group in args.adata_obs_fields_to_merge.split(":"):
             fields = group.split(",")
             check_fields(fields, adata)
             adata = merge_adata_obs_fields(fields, adata)

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -8,14 +8,14 @@ mkdir deseq_output_dir &&
 mkdir plots_output_dir &&
 python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
     #if $adata_obs_fields_to_merge:
-    --adata_obs_fields_to_merge $adata_obs_fields_to_merge
+    --adata_obs_fields_to_merge '$adata_obs_fields_to_merge'
     #end if
-    --groupby $groupby
-    --sample_key $sample_key
+    --groupby '$groupby'
+    --sample_key '$sample_key'
     #if $layer:
-    --layer $layer
+    --layer '$layer'
     #end if
-    --mode $mode
+    --mode '$mode'
     #if $use_raw:
     --use_raw
     #end if
@@ -32,7 +32,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
     --min_total_counts $min_total_counts
     #end if
     #if $produce_anndata:
-    --anndata_output_path $pbulk_anndata
+    --anndata_output_path '$pbulk_anndata'
     #end if
     #if $filter_expr:
     --filter_expr
@@ -50,7 +50,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
     </environment_variables>
     <inputs>
         <param type="data" name="input_file" format="data" label="Input AnnData file"/>
-        <param type="text" name="adata_obs_fields_to_merge" label="Obs Fields to Merge" optional="true" help="Fields in adata.obs to merge, comma separated (optional). They will be available as field1_field2_field3 in the AnnData Obs dataframe. You can have multiple groups to merge, separated by ';'"/>
+        <param type="text" name="adata_obs_fields_to_merge" label="Obs Fields to Merge" optional="true" help="Fields in adata.obs to merge, comma separated (optional). They will be available as field1_field2_field3 in the AnnData Obs dataframe. You can have multiple groups to merge, separated by colon (:)."/>
         <param type="text" name="groupby" label="Groupby column" help="The column in adata.obs that defines the groups. Merged columns in the above field are available here."/>
         <param type="text" name="sample_key" label="Sample Key column" help="The column in adata.obs that defines the samples. Merged columns in the above field are available here."/>
         <param type="text" name="layer" label="Layer" optional="true" help="The name of the layer of the AnnData object to use. It needs to be present in the AnnData object."/>
@@ -87,7 +87,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
     <tests>
         <test expect_num_outputs="6">
             <param name="input_file" value="mito_counted_anndata.h5ad"/>
-            <param name="adata_obs_fields_to_merge" value="batch,sex;batch,genotype"/>
+            <param name="adata_obs_fields_to_merge" value="batch,sex:batch,genotype"/>
             <param name="groupby" value="batch_sex"/>
             <param name="sample_key" value="genotype"/>
             <param name="factor_fields" value="genotype,batch_sex"/>

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -1,4 +1,4 @@
-<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy1" profile="20.05">
+<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy2" profile="20.05">
     <description>aggregates single cell RNA-seq data for running bulk RNA-seq methods</description>
     <requirements>
         <requirement type="package" version="1.4.0">decoupler</requirement>
@@ -50,7 +50,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
     </environment_variables>
     <inputs>
         <param type="data" name="input_file" format="data" label="Input AnnData file"/>
-        <param type="text" name="adata_obs_fields_to_merge" label="Obs Fields to Merge" optional="true" help="Fields in adata.obs to merge, comma separated (optional). They will be available as field1_field2_field3 in the AnnData Obs dataframe."/>
+        <param type="text" name="adata_obs_fields_to_merge" label="Obs Fields to Merge" optional="true" help="Fields in adata.obs to merge, comma separated (optional). They will be available as field1_field2_field3 in the AnnData Obs dataframe. You can have multiple groups to merge, separated by ';'"/>
         <param type="text" name="groupby" label="Groupby column" help="The column in adata.obs that defines the groups. Merged columns in the above field are available here."/>
         <param type="text" name="sample_key" label="Sample Key column" help="The column in adata.obs that defines the samples. Merged columns in the above field are available here."/>
         <param type="text" name="layer" label="Layer" optional="true" help="The name of the layer of the AnnData object to use. It needs to be present in the AnnData object."/>
@@ -87,7 +87,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
     <tests>
         <test expect_num_outputs="6">
             <param name="input_file" value="mito_counted_anndata.h5ad"/>
-            <param name="adata_obs_fields_to_merge" value="batch,sex"/>
+            <param name="adata_obs_fields_to_merge" value="batch,sex;batch,genotype"/>
             <param name="groupby" value="batch_sex"/>
             <param name="sample_key" value="genotype"/>
             <param name="factor_fields" value="genotype,batch_sex"/>


### PR DESCRIPTION
# Description

This adds functionality for the decoupler pseudo_bulk to be able to merge multiple groups of fields and not just a single one.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
