### PR TITLE
Decoupler AUCell var improvement and optional gene sets

### DIFF
--- a/tools/tertiary-analysis/decoupler/decoupler_aucell_score.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_aucell_score.py
@@ -109,15 +109,20 @@ def run_for_genelists(
 if __name__ == "__main__":
     # Create command-line arguments parser
     parser = argparse.ArgumentParser(description="Score genes using Aucell")
-    parser.add_argument("--input_file", type=str, help="Path to input AnnData file")
-    parser.add_argument("--output_file", type=str, help="Path to output file")
+    parser.add_argument(
+        "--input_file", type=str, help="Path to input AnnData file", required=True
+    )
+    parser.add_argument(
+        "--output_file", type=str, help="Path to output file", required=True
+    )
     parser.add_argument("--gmt_file", type=str, help="Path to GMT file", required=False)
     # add argument for gene sets to score
     parser.add_argument(
         "--gene_sets_to_score",
         type=str,
+        default="",
         required=False,
-        help="Comma separated list of gene sets to score (the need to be in the gmt file)",
+        help="Optional comma separated list of gene sets to score (the need to be in the gmt file)",
     )
     # add argument for gene list (comma separated) to score
     parser.add_argument(
@@ -137,6 +142,7 @@ if __name__ == "__main__":
         "--gene_symbols_field",
         type=str,
         help="Name of the gene symbols field in the AnnData object",
+        required=True,
     )
     parser.add_argument("--use_raw", action="store_true", help="Use raw data")
     parser.add_argument(
@@ -149,7 +155,7 @@ if __name__ == "__main__":
     # Load input AnnData object
     adata = anndata.read_h5ad(args.input_file)
 
-    if args.gene_sets_to_score is not None and args.gmt_file is not None:
+    if args.gmt_file is not None:
         # Load MSigDB file in GMT format
         msigdb = read_gmt(args.gmt_file)
 
@@ -157,7 +163,7 @@ if __name__ == "__main__":
         # Score genes by their ensembl ids using the score_genes_aucell function
         for _, row in msigdb.iterrows():
             gene_set_name = row["gene_set_name"]
-            if gene_set_name in gene_sets_to_score:
+            if gene_set_name in gene_sets_to_score or not gene_sets_to_score:
                 genes = row["genes"].split(",")
                 # Convert gene symbols to ensembl ids by using the columns gene_symbols and index in adata.var specific to the gene set
                 ens_gene_ids = adata.var[

--- a/tools/tertiary-analysis/decoupler/decoupler_aucell_score.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_aucell_score.py
@@ -120,7 +120,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--gene_sets_to_score",
         type=str,
-        default="",
         required=False,
         help="Optional comma separated list of gene sets to score (the need to be in the gmt file)",
     )
@@ -159,11 +158,11 @@ if __name__ == "__main__":
         # Load MSigDB file in GMT format
         msigdb = read_gmt(args.gmt_file)
 
-        gene_sets_to_score = args.gene_sets_to_score.split(",")
+        gene_sets_to_score = args.gene_sets_to_score.split(",") if args.gene_sets_to_score else []
         # Score genes by their ensembl ids using the score_genes_aucell function
         for _, row in msigdb.iterrows():
             gene_set_name = row["gene_set_name"]
-            if gene_set_name in gene_sets_to_score or not gene_sets_to_score:
+            if not gene_sets_to_score or gene_set_name in gene_sets_to_score:
                 genes = row["genes"].split(",")
                 # Convert gene symbols to ensembl ids by using the columns gene_symbols and index in adata.var specific to the gene set
                 ens_gene_ids = adata.var[

--- a/tools/tertiary-analysis/decoupler/decoupler_aucell_score.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_aucell_score.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="score_genes_aucell" name="Decoupler AUCell" version="1.4.0+galaxy0" profile="20.05">
+<tool id="score_genes_aucell" name="Decoupler AUCell" version="1.4.0+galaxy1" profile="20.05">
     <description>
         scores cells using the AUCell method for gene sets.
     </description>
@@ -10,11 +10,13 @@
         python '$__tool_directory__/decoupler_aucell_score.py'
             --input_file '$input_file'
             #if $gene_lists_source.source == "gmt"
-            --gmt_file '$gmt_file'
-            --gene_sets_to_score '$gene_sets_to_score'
+            --gmt_file '$gene_lists_source.gmt_file'
+            #if $gene_lists_source.gene_sets_to_score
+            --gene_sets_to_score '$gene_lists_source.gene_sets_to_score'
+            #end if
             #else:
-            --gene_lists_to_score '$gene_lists_to_score'
-            --score_names '$score_names'
+            --gene_lists_to_score '$gene_lists_source.gene_lists_to_score'
+            --score_names '$gene_lists_source.score_names'
             #end if
             --gene_symbols_field '$gene_symbols_field'
             $use_raw
@@ -34,7 +36,7 @@
             </param>
             <when value="gmt">
                 <param name="gmt_file" type="data" format="txt" label="GMT file with gene sets" />
-                <param name="gene_sets_to_score" type="text" label="Gene sets to score within the GMT file" />
+                <param name="gene_sets_to_score" type="text" optional="true" label="Gene sets to score within the GMT file" />
             </when>
             <when value="enumerated">
                 <param name="gene_lists_to_score" type="text" label="Genes to score" />
@@ -56,11 +58,11 @@
     <tests>
         <test expect_num_outputs="1">
             <param name="input_file" value="mito_counted_anndata.h5ad"/>
-            <param name="gene_sets_to_score" value="HALLMARK_NOTCH_SIGNALING,HALLMARK_APICAL_SURFACE"/>
-            <param name="gmt_file" value="mouse_hallmark_ss.gmt"/>
             <param name="gene_symbols_field" value="Symbol"/>
             <param name="write_anndata" value="true"/>
             <conditional name="gene_lists_source">
+                <param name="gene_sets_to_score" value="HALLMARK_NOTCH_SIGNALING,HALLMARK_APICAL_SURFACE"/>
+                <param name="gmt_file" value="mouse_hallmark_ss.gmt"/>
                 <param name="source" value="gmt"/>
             </conditional>
             <output name="output_ad">
@@ -72,12 +74,27 @@
         </test>
         <test expect_num_outputs="1">
             <param name="input_file" value="mito_counted_anndata.h5ad"/>
-            <param name="gene_lists_to_score" value="Cd8b1,Cd8b2,Cd8a,Cd4,Nrp1,Cd80:Il1a,Il1b,Il6,Nos2,Tlr2,Tlr4,Cd80"/>
-            <param name="score_names" value="TCell,Macro"/>
+            <param name="gene_symbols_field" value="Symbol"/>
+            <param name="write_anndata" value="true"/>
+            <conditional name="gene_lists_source">
+                <param name="source" value="gmt"/>
+                <param name="gmt_file" value="mouse_hallmark_ss.gmt"/>
+            </conditional>
+            <output name="output_ad">
+                <assert_contents>
+                    <has_h5_keys keys="obs/AUCell_HALLMARK_NOTCH_SIGNALING"/>
+                    <has_h5_keys keys="obs/AUCell_HALLMARK_APICAL_SURFACE"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="input_file" value="mito_counted_anndata.h5ad"/>
             <param name="gene_symbols_field" value="Symbol"/>
             <param name="write_anndata" value="true"/>
             <conditional name="gene_lists_source">
                 <param name="source" value="enumerated"/>
+                <param name="gene_lists_to_score" value="Cd8b1,Cd8b2,Cd8a,Cd4,Nrp1,Cd80:Il1a,Il1b,Il6,Nos2,Tlr2,Tlr4,Cd80"/>
+                <param name="score_names" value="TCell,Macro"/>
             </conditional>
             <output name="output_ad">
                 <assert_contents>
@@ -88,12 +105,12 @@
         </test>
         <test expect_num_outputs="1">
             <param name="input_file" value="mito_counted_anndata.h5ad"/>
-            <param name="gene_sets_to_score" value="HALLMARK_NOTCH_SIGNALING,HALLMARK_APICAL_SURFACE"/>
-            <param name="gmt_file" value="mouse_hallmark_ss.gmt"/>
             <param name="gene_symbols_field" value="Symbol"/>
             <param name="write_anndata" value="False"/>
             <conditional name="gene_lists_source">
                 <param name="source" value="gmt"/>
+                <param name="gene_sets_to_score" value="HALLMARK_NOTCH_SIGNALING,HALLMARK_APICAL_SURFACE"/>
+                <param name="gmt_file" value="mouse_hallmark_ss.gmt"/>
             </conditional>
             <output name="output_table">
                 <assert_contents>


### PR DESCRIPTION
# Description

Fixes some issues not detected by planemo testing (namespace of conditional variables not required by planemo but required by Galaxy exec). Also makes the file with sub selection of gene sets optional (then the whole GMT is run).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
