### PR TITLE
AUCell handle cases with less than min genes

### DIFF
--- a/tools/tertiary-analysis/decoupler/decoupler_aucell_score.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_aucell_score.py
@@ -80,11 +80,15 @@ def score_genes_aucell(
         }
     )
     # run decoupler's run_aucell
-    dc.run_aucell(
-        adata, net=geneset_df, source="geneset", target="gene_id", use_raw=use_raw
-    )
-    # copy .obsm['aucell_estimate'] matrix columns to adata.obs using the column names
-    adata.obs[score_name] = adata.obsm["aucell_estimate"][score_name]
+    # catch the value error
+    try:
+        dc.run_aucell(
+            adata, net=geneset_df, source="geneset", target="gene_id", use_raw=use_raw
+        )
+        # copy .obsm['aucell_estimate'] matrix columns to adata.obs using the column names
+        adata.obs[score_name] = adata.obsm["aucell_estimate"][score_name]
+    except ValueError as ve:
+        print(f"Gene list {score_name} failed, skipping: {str(ve)}")
 
 
 def run_for_genelists(
@@ -158,7 +162,9 @@ if __name__ == "__main__":
         # Load MSigDB file in GMT format
         msigdb = read_gmt(args.gmt_file)
 
-        gene_sets_to_score = args.gene_sets_to_score.split(",") if args.gene_sets_to_score else []
+        gene_sets_to_score = (
+            args.gene_sets_to_score.split(",") if args.gene_sets_to_score else []
+        )
         # Score genes by their ensembl ids using the score_genes_aucell function
         for _, row in msigdb.iterrows():
             gene_set_name = row["gene_set_name"]

--- a/tools/tertiary-analysis/decoupler/decoupler_aucell_score.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_aucell_score.xml
@@ -22,6 +22,7 @@
             $use_raw
             #if $min_n_genes:
             --min_n '$min_n_genes'
+            #end if
             #if $write_anndata:
             --write_anndata
             --output_file anndata_aucell.h5ad

--- a/tools/tertiary-analysis/decoupler/decoupler_aucell_score.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_aucell_score.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="score_genes_aucell" name="Decoupler AUCell" version="1.4.0+galaxy1" profile="20.05">
+<tool id="score_genes_aucell" name="Decoupler AUCell" version="1.4.0+galaxy2" profile="20.05">
     <description>
         scores cells using the AUCell method for gene sets.
     </description>
@@ -20,6 +20,8 @@
             #end if
             --gene_symbols_field '$gene_symbols_field'
             $use_raw
+            #if $min_n_genes:
+            --min_n '$min_n_genes'
             #if $write_anndata:
             --write_anndata
             --output_file anndata_aucell.h5ad
@@ -43,6 +45,7 @@
                 <param name="score_names" type="text" label="Score names" />
             </when>
         </conditional>
+        <param name="min_n_genes" type="integer" label="Minimum number of genes" help="Minimum number of genes to match in each gene set" optional="true" value="5"/>
         <param name="gene_symbols_field" type="text" label="Gene symbols field" help="The field in the AnnData var table where gene symbols are stored."/>
         <param name="use_raw" type="boolean" value="false" truevalue="--use_raw" falsevalue="" label="Use raw data" help="Use RAW data in the AnnData instead of the X matrix."/>
         <param name="write_anndata" type="boolean" value="false" truevalue="--write_anndata" falsevalue="" label="Write the modified AnnData object" help="Whether to write or not the same AnnData file again with the signatures on it. If unselected, a text files of cells in rows and signatures in columns (as in Obs) is produced."/>


### PR DESCRIPTION
# Description

Allows to set the min n for AUCell calculations and also skips faulty gene sets instead of failing completely.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
