### PR TITLE
Adds PySCENIC wrappers

### DIFF
--- a/tools/tertiary-analysis/pyscenic/.shed.yml
+++ b/tools/tertiary-analysis/pyscenic/.shed.yml
@@ -1,0 +1,21 @@
+categories:
+ - Transcriptomics
+ - RNA
+ - Sequence Analysis
+description: "PySCENIC scripts based on usage at https://pyscenic.readthedocs.io/"
+long_description: |
+        pySCENIC is a lightning-fast python implementation of the SCENIC pipeline (Single-Cell rEgulatory Network Inference and Clustering) 
+        which enables biologists to infer transcription factors, gene regulatory networks and cell types from single-cell RNA-seq data.
+name: suite_pyscenic
+owner: ebi-gxa
+remote_repository_url: https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/
+type: unrestricted
+auto_tool_repositories:
+  name_template: "{{ tool_id }}"
+  description_template: "Wrapper for the pySCENIC tool suite: {{ tool_name }}"
+suite:
+  name: "suite_pyscenic"
+  description: "PySCENIC scripts based on usage at https://pyscenic.readthedocs.io/"
+  long_description: |
+    pySCENIC is a lightning-fast python implementation of the SCENIC pipeline (Single-Cell rEgulatory Network Inference and Clustering) 
+    which enables biologists to infer transcription factors, gene regulatory networks and cell types from single-cell RNA-seq data.

--- a/tools/tertiary-analysis/pyscenic/get_test_data.sh
+++ b/tools/tertiary-analysis/pyscenic/get_test_data.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+TF_DATA_LINK='https://raw.githubusercontent.com/aertslab/scenic-nf/master/example/allTFs_hg38.txt'
+MOTIF2TF_LINK='https://raw.githubusercontent.com/aertslab/scenic-nf/master/example/motifs.tbl'
+RANKING_LINK='https://raw.githubusercontent.com/aertslab/scenic-nf/master/example/genome-ranking.feather'
+LOOM_INPUT_LINK='https://raw.githubusercontent.com/aertslab/scenic-nf/master/example/expr_mat.loom'
+
+function get_data {
+  local link=$1
+  local fname=$2
+
+  if [ ! -f $fname ]; then
+    echo "$fname not available locally, downloading.."
+    wget -O $fname --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 $link
+  fi
+}
+
+# get matrix data
+mkdir -p test-data
+pushd test-data
+get_data $TF_DATA_LINK "allTFs_hg38.txt"
+#unzip mtx.zip
+#rm -f mtx.zip
+
+get_data $MOTIF2TF_LINK "motifs.tbl"
+get_data $RANKING_LINK "genome-ranking.feather"
+get_data $LOOM_INPUT_LINK "expr_mat.loom"

--- a/tools/tertiary-analysis/pyscenic/get_test_data.sh
+++ b/tools/tertiary-analysis/pyscenic/get_test_data.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 TF_DATA_LINK='https://raw.githubusercontent.com/aertslab/scenic-nf/master/example/allTFs_hg38.txt'
 MOTIF2TF_LINK='https://raw.githubusercontent.com/aertslab/scenic-nf/master/example/motifs.tbl'
-RANKING_LINK='https://raw.githubusercontent.com/aertslab/scenic-nf/master/example/genome-ranking.feather'
+RANKING_LINK='https://zenodo.org/records/13328724/files/genome-ranking_v2.feather'
 LOOM_INPUT_LINK='https://raw.githubusercontent.com/aertslab/scenic-nf/master/example/expr_mat.loom'
+
+REGULONS_LINK='https://zenodo.org/records/13328724/files/regulons.tsv'
+TF2TARGETS_LINK='https://zenodo.org/records/13328724/files/tf2targets.tsv'
 
 function get_data {
   local link=$1
@@ -18,9 +21,8 @@ function get_data {
 mkdir -p test-data
 pushd test-data
 get_data $TF_DATA_LINK "allTFs_hg38.txt"
-#unzip mtx.zip
-#rm -f mtx.zip
-
 get_data $MOTIF2TF_LINK "motifs.tbl"
-get_data $RANKING_LINK "genome-ranking.feather"
+get_data $RANKING_LINK "genome-ranking_v2.feather"
 get_data $LOOM_INPUT_LINK "expr_mat.loom"
+get_data $REGULONS_LINK regulons.tsv
+get_data $TF2TARGETS_LINK tf2targets.tsv

--- a/tools/tertiary-analysis/pyscenic/macros.xml
+++ b/tools/tertiary-analysis/pyscenic/macros.xml
@@ -1,8 +1,9 @@
 <macros>
+    <token name="@TOOL_VERSION@">0.12.1</token>
     <xml name="requirements">
         <requirements>
             <container type="docker">
-            aertslab/pyscenic:0.12.1
+            aertslab/pyscenic:@TOOL_VERSION@
         </container>
         </requirements>
     </xml>

--- a/tools/tertiary-analysis/pyscenic/macros.xml
+++ b/tools/tertiary-analysis/pyscenic/macros.xml
@@ -1,0 +1,14 @@
+<macros>
+    <xml name="requirements">
+        <requirements>
+            <container type="docker">
+            aertslab/pyscenic:0.12.1
+        </container>
+        </requirements>
+    </xml>
+    <xml name="citations">
+        <citations>
+            <citation type="doi">10.1038/nmeth.4463</citation>
+        </citations>
+    </xml>
+</macros>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -11,9 +11,7 @@
         pyscenic aucell expr_mat.loom regulons.tsv
            -o aucell.tsv
         $transpose
-        #if $weights
-           -w
-        #end if
+        $weights
        --num_workers \${GALAXY_SLOTS:-1}
         #if $seed
            --seed '${seed}'
@@ -41,7 +39,7 @@
         <param name="expression_mtx_fname" format="loom" type="data" label="Expression Matrix File" help="The file that contains the expression matrix for the single-cell experiment. Supported formats: csv (rows=cells x columns=genes) or loom (rows=genes x columns=cells)."/>
         <param name="signatures_fname" type="data" format="csv,tabular" label="Gene Signatures/Regulons File" help="The file that contains the gene signatures (usually the precomputed regulons). Currently only csv/tsv supported, could be extended."/>
         <param type="boolean" name="transpose" label="Transpose Expression Matrix" truevalue="-t" falsevalue="" help="Use this if the matrix is cell x genes instead of genes x cells as expected"/>
-        <param name="weights" type="boolean" label="Use Weights for Recovery Analysis" help="Use weights associated with genes in recovery analysis. Relevant when gene signatures are supplied as json format." optional="true"/>
+        <param name="weights" type="boolean" label="Use Weights for Recovery Analysis" truevalue="-w" falsevalue="" help="Use weights associated with genes in recovery analysis. Relevant when gene signatures are supplied as json format."/>
         <param name="seed" type="integer" label="Seed for Ranking" help="Seed for the expression matrix ranking step. The default is to use a random seed." optional="true"/>
         <param name="rank_threshold" type="integer" label="Rank Threshold" help="The rank threshold used for deriving the target genes of an enriched motif (default: 5000)." optional="true"/>
         <param name="auc_threshold" type="float" label="AUC Threshold" help="The threshold used for calculating the AUC of a feature as fraction of ranked genes (default: 0.05)." optional="true"/>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -60,7 +60,12 @@
         <test expect_num_outputs="1">
             <param name="expression_mtx_fname" value="expr_mat.loom"/>
             <param name="signatures_fname" value="regulons.tsv"/>
-            <output name="output" file="aucell_regulons.tsv" compare="sim_size" delta_frac="0.2"/>
+            <output name="output">
+                <assert_contents>
+                    <has_n_lines n="101"/>
+                    <has_text text="CEBPB"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -1,4 +1,4 @@
-<tool id="pyscenic_aucell" name="PySCENIC AUCell" profile="21.09" version="0.12.1+galaxy0">
+<tool id="pyscenic_aucell" name="PySCENIC AUCell" profile="21.09" version="@TOOL_VERSION@+galaxy0">
     <description>calculates AUCell to find relevant regulons/gene sets</description>
     <macros>
         <import>macros.xml</import>
@@ -10,9 +10,7 @@
 
         pyscenic aucell expr_mat.loom regulons.tsv
            -o aucell.tsv
-        #if $transpose
-           -t
-        #end if
+        $transpose
         #if $weights
            -w
         #end if
@@ -42,7 +40,7 @@
     <inputs>
         <param name="expression_mtx_fname" format="loom" type="data" label="Expression Matrix File" help="The file that contains the expression matrix for the single-cell experiment. Supported formats: csv (rows=cells x columns=genes) or loom (rows=genes x columns=cells)."/>
         <param name="signatures_fname" type="data" format="csv,tabular" label="Gene Signatures/Regulons File" help="The file that contains the gene signatures (usually the precomputed regulons). Currently only csv/tsv supported, could be extended."/>
-        <param name="transpose" type="boolean" label="Transpose Expression Matrix" help="Transpose the expression matrix if supplied as csv (rows=genes x columns=cells)." optional="true"/>
+        <param type="boolean" name="transpose" label="Transpose Expression Matrix" truevalue="-t" falsevalue="" help="Use this if the matrix is cell x genes instead of genes x cells as expected"/>
         <param name="weights" type="boolean" label="Use Weights for Recovery Analysis" help="Use weights associated with genes in recovery analysis. Relevant when gene signatures are supplied as json format." optional="true"/>
         <param name="seed" type="integer" label="Seed for Ranking" help="Seed for the expression matrix ranking step. The default is to use a random seed." optional="true"/>
         <param name="rank_threshold" type="integer" label="Rank Threshold" help="The rank threshold used for deriving the target genes of an enriched motif (default: 5000)." optional="true"/>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -1,10 +1,9 @@
 <tool id="pyscenic_aucell" name="PySCENIC AUCell" profile="21.09" version="0.12.1+galaxy0">
     <description>calculates AUCell to find relevant regulons/gene sets</description>
-    <requirements>
-        <container type="docker">
-            aertslab/pyscenic:0.12.1
-        </container>
-    </requirements>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
     <command><![CDATA[
         ln -s '${expression_mtx_fname}' expr_mat.loom &&
         ln -s '${signatures_fname}' regulons.tsv &&
@@ -105,7 +104,5 @@
           - **--sparse**: If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only.
         ]]>
       </help>
-    <citations>
-        <citation type="doi">10.1038/nmeth.4463</citation>
-    </citations>
+    <expand macro="citations"/>
 </tool>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -6,8 +6,8 @@
         </container>
     </requirements>
     <command><![CDATA[
-        ln -s "${expression_mtx_fname}" expr_mat.loom &&
-        ln -s "${signatures_fname}" regulons.tsv &&
+        ln -s '${expression_mtx_fname}' expr_mat.loom &&
+        ln -s '${signatures_fname}' regulons.tsv &&
 
         pyscenic aucell expr_mat.loom regulons.tsv
            -o aucell.tsv
@@ -19,44 +19,42 @@
         #end if
        --num_workers \${GALAXY_SLOTS:-1}
         #if $seed
-           --seed "${seed}"
+           --seed '${seed}'
         #end if
         #if str($rank_threshold):
-           --rank_threshold "${rank_threshold}"
+           --rank_threshold '${rank_threshold}'
         #end if
         #if $auc_threshold
-           --auc_threshold "${auc_threshold}"
+           --auc_threshold '${auc_threshold}'
         #end if
         #if $nes_threshold
-           --nes_threshold "${nes_threshold}"
+           --nes_threshold '${nes_threshold}'
         #end if
         #if $cell_id_attribute
-           --cell_id_attribute "${cell_id_attribute}"
+           --cell_id_attribute '${cell_id_attribute}'
         #end if
         #if $gene_attribute
-           --gene_attribute "${gene_attribute}"
+           --gene_attribute '${gene_attribute}'
         #end if
         $sparse
 
-        && mv aucell.tsv "${output}"
+        && mv aucell.tsv '${output}'
     ]]></command>
-  
     <inputs>
-      <param name="expression_mtx_fname" format="loom" type="data" label="Expression Matrix File" help="The file that contains the expression matrix for the single-cell experiment. Supported formats: csv (rows=cells x columns=genes) or loom (rows=genes x columns=cells)." />
-      <param name="signatures_fname" type="data" format="csv,tabular" label="Gene Signatures/Regulons File" help="The file that contains the gene signatures (usually the precomputed regulons). Currently only csv/tsv supported, could be extended." />
-      <param name="transpose" type="boolean" label="Transpose Expression Matrix" help="Transpose the expression matrix if supplied as csv (rows=genes x columns=cells)." optional="true" />
-      <param name="weights" type="boolean" label="Use Weights for Recovery Analysis" help="Use weights associated with genes in recovery analysis. Relevant when gene signatures are supplied as json format." optional="true" />
-      <param name="seed" type="integer" label="Seed for Ranking" help="Seed for the expression matrix ranking step. The default is to use a random seed." optional="true" />
-      <param name="rank_threshold" type="integer" label="Rank Threshold" help="The rank threshold used for deriving the target genes of an enriched motif (default: 5000)." optional="true" />
-      <param name="auc_threshold" type="float" label="AUC Threshold" help="The threshold used for calculating the AUC of a feature as fraction of ranked genes (default: 0.05)." optional="true" />
-      <param name="nes_threshold" type="float" label="NES Threshold" help="The Normalized Enrichment Score (NES) threshold for finding enriched features (default: 3.0)." optional="true" />
-      <param name="cell_id_attribute" type="text" label="Cell ID Attribute" help="The name of the column attribute that specifies the identifiers of the cells in the loom file." optional="true" />
-      <param name="gene_attribute" type="text" label="Gene Attribute" help="The name of the row attribute that specifies the gene symbols in the loom file." optional="true" />
-      <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only." optional="true" />
+        <param name="expression_mtx_fname" format="loom" type="data" label="Expression Matrix File" help="The file that contains the expression matrix for the single-cell experiment. Supported formats: csv (rows=cells x columns=genes) or loom (rows=genes x columns=cells)."/>
+        <param name="signatures_fname" type="data" format="csv,tabular" label="Gene Signatures/Regulons File" help="The file that contains the gene signatures (usually the precomputed regulons). Currently only csv/tsv supported, could be extended."/>
+        <param name="transpose" type="boolean" label="Transpose Expression Matrix" help="Transpose the expression matrix if supplied as csv (rows=genes x columns=cells)." optional="true"/>
+        <param name="weights" type="boolean" label="Use Weights for Recovery Analysis" help="Use weights associated with genes in recovery analysis. Relevant when gene signatures are supplied as json format." optional="true"/>
+        <param name="seed" type="integer" label="Seed for Ranking" help="Seed for the expression matrix ranking step. The default is to use a random seed." optional="true"/>
+        <param name="rank_threshold" type="integer" label="Rank Threshold" help="The rank threshold used for deriving the target genes of an enriched motif (default: 5000)." optional="true"/>
+        <param name="auc_threshold" type="float" label="AUC Threshold" help="The threshold used for calculating the AUC of a feature as fraction of ranked genes (default: 0.05)." optional="true"/>
+        <param name="nes_threshold" type="float" label="NES Threshold" help="The Normalized Enrichment Score (NES) threshold for finding enriched features (default: 3.0)." optional="true"/>
+        <param name="cell_id_attribute" type="text" label="Cell ID Attribute" help="The name of the column attribute that specifies the identifiers of the cells in the loom file." optional="true"/>
+        <param name="gene_attribute" type="text" label="Gene Attribute" help="The name of the row attribute that specifies the gene symbols in the loom file." optional="true"/>
+        <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only." optional="true"/>
     </inputs>
-  
     <outputs>
-      <data name="output" format="tsv" label="${tool.name} on ${on_string}: AUCell scores for regulons or gene sets." />
+        <data name="output" format="tsv" label="${tool.name} on ${on_string}: AUCell scores for regulons or gene sets."/>
     </outputs>
     <tests>
         <test expect_num_outputs="1">
@@ -105,4 +103,4 @@
     <citations>
         <citation type="doi">10.1038/nmeth.4463</citation>
     </citations>
-  </tool>
+</tool>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -1,0 +1,110 @@
+<tool id="pyscenic_aucell" name="PySCENIC aucell" profile="21.09" version="1.0.0">
+    <description>calculates most relevant regulons</description>
+    <requirements>
+        <container type="docker">
+            aertslab/pyscenic:0.12.1
+        </container>
+    </requirements>
+    <command><![CDATA[
+        ln -s "${expression_mtx_fname}" expr_mat.loom &&
+        ln -s "${signatures_fname}" regulons.tsv &&
+
+        pyscenic aucell expr_mat.loom regulons.tsv
+           -o aucell.tsv
+        #if $transpose
+           -t
+        #end if
+        #if $weights
+           -w
+        #end if
+           --num_workers \${GALAXY_SLOTS:-1}
+        #if $seed
+           --seed "${seed}"
+        #end if
+        #if $rank_threshold
+           --rank_threshold "${rank_threshold}"
+        #end if
+        #if $auc_threshold
+           --auc_threshold "${auc_threshold}"
+        #end if
+        #if $nes_threshold
+           --nes_threshold "${nes_threshold}"
+        #end if
+        #if $cell_id_attribute
+           --cell_id_attribute "${cell_id_attribute}"
+        #end if
+        #if $gene_attribute
+           --gene_attribute "${gene_attribute}"
+        #end if
+        #if $sparse
+           --sparse
+        #end if
+
+        && mv aucell.tsv "${output}"
+    ]]></command>
+  
+    <inputs>
+      <param name="expression_mtx_fname" format="loom" type="data" label="Expression Matrix File" help="The file that contains the expression matrix for the single-cell experiment. Supported formats: csv (rows=cells x columns=genes) or loom (rows=genes x columns=cells)." />
+      <param name="signatures_fname" type="data" format="csv,tabular" label="Gene Signatures/Regulons File" help="The file that contains the gene signatures (usually the precomputed regulons). Currently only csv/tsv supported, could be extended." />
+      <param name="transpose" type="boolean" label="Transpose Expression Matrix" help="Transpose the expression matrix if supplied as csv (rows=genes x columns=cells)." optional="true" />
+      <param name="weights" type="boolean" label="Use Weights for Recovery Analysis" help="Use weights associated with genes in recovery analysis. Relevant when gene signatures are supplied as json format." optional="true" />
+      <param name="seed" type="integer" label="Seed for Ranking" help="Seed for the expression matrix ranking step. The default is to use a random seed." optional="true" />
+      <param name="rank_threshold" type="integer" label="Rank Threshold" help="The rank threshold used for deriving the target genes of an enriched motif (default: 5000)." optional="true" />
+      <param name="auc_threshold" type="float" label="AUC Threshold" help="The threshold used for calculating the AUC of a feature as fraction of ranked genes (default: 0.05)." optional="true" />
+      <param name="nes_threshold" type="float" label="NES Threshold" help="The Normalized Enrichment Score (NES) threshold for finding enriched features (default: 3.0)." optional="true" />
+      <param name="cell_id_attribute" type="text" label="Cell ID Attribute" help="The name of the column attribute that specifies the identifiers of the cells in the loom file." optional="true" />
+      <param name="gene_attribute" type="text" label="Gene Attribute" help="The name of the row attribute that specifies the gene symbols in the loom file." optional="true" />
+      <param name="sparse" type="boolean" label="Sparse Matrix" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only." optional="true" />
+    </inputs>
+  
+    <outputs>
+      <data name="output" format="tsv" label="${tool.name} on ${on_string}: AUCell scores for regulons or gene sets." />
+    </outputs>
+    <tests>
+        <test expect_num_outputs="1">
+            <param name="expression_mtx_fname" value="expr_mat.loom"/>
+            <param name="signatures_fname" value="regulons.tsv"/>
+            <output name="output" file="aucell_regulons.tsv" compare="sim_size" delta_frac="0.2"/>
+        </test>
+    </tests>
+    <help>
+        <![CDATA[
+          Run PySCENIC aucell command to analyze single-cell gene expression data.
+    
+          **Input Parameters:**
+    
+          - **expression_mtx_fname**: The name of the file that contains the expression matrix for the single cell experiment. Two file formats are supported: csv (rows=cells x columns=genes) or loom (rows=genes x columns=cells).
+    
+          - **signatures_fname**: The name of the file that contains the gene signatures. Three file formats are supported: gmt, yaml, or dat (pickle).
+    
+          **Options:**
+    
+          - **-o, --output**: Output file/stream, a matrix of AUC values. Two file formats are supported: csv or loom. If loom file is specified, it will contain the original expression matrix and the calculated AUC values as extra column attributes.
+    
+          - **-t, --transpose**: Transpose the expression matrix if supplied as csv (rows=genes x columns=cells).
+    
+          - **-w, --weights**: Use weights associated with genes in recovery analysis. Is only relevant when gene signatures are supplied as json format.
+    
+          - **--seed**: Seed for the expression matrix ranking step. The default is to use a random seed.
+    
+          **Motif Enrichment Arguments:**
+    
+          - **--rank_threshold**: The rank threshold used for deriving the target genes of an enriched motif (default: 5000).
+    
+          - **--auc_threshold**: The threshold used for calculating the AUC of a feature as fraction of ranked genes (default: 0.05).
+    
+          - **--nes_threshold**: The Normalized Enrichment Score (NES) threshold for finding enriched features (default: 3.0).
+    
+          **Loom File Arguments:**
+    
+          - **--cell_id_attribute**: The name of the column attribute that specifies the identifiers of the cells in the loom file.
+    
+          - **--gene_attribute**: The name of the row attribute that specifies the gene symbols in the loom file.
+    
+          - **--sparse**: If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only.
+        ]]>
+      </help>
+    <citations>
+        <citation type="doi">10.1038/nmeth.4463</citation>
+    </citations>
+  </tool>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -51,7 +51,7 @@
         <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only."/>
     </inputs>
     <outputs>
-        <data name="output" format="tsv" label="${tool.name} on ${on_string}: AUCell scores for regulons or gene sets."/>
+        <data name="output" format="tabular" label="${tool.name} on ${on_string}: AUCell scores for regulons or gene sets."/>
     </outputs>
     <tests>
         <test expect_num_outputs="1">

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -51,7 +51,7 @@
         <param name="nes_threshold" type="float" label="NES Threshold" help="The Normalized Enrichment Score (NES) threshold for finding enriched features (default: 3.0)." optional="true"/>
         <param name="cell_id_attribute" type="text" label="Cell ID Attribute" help="The name of the column attribute that specifies the identifiers of the cells in the loom file." optional="true"/>
         <param name="gene_attribute" type="text" label="Gene Attribute" help="The name of the row attribute that specifies the gene symbols in the loom file." optional="true"/>
-        <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only." optional="true"/>
+        <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only."/>
     </inputs>
     <outputs>
         <data name="output" format="tsv" label="${tool.name} on ${on_string}: AUCell scores for regulons or gene sets."/>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -1,5 +1,5 @@
-<tool id="pyscenic_aucell" name="PySCENIC aucell" profile="21.09" version="1.0.0">
-    <description>calculates most relevant regulons</description>
+<tool id="pyscenic_aucell" name="PySCENIC AUCell" profile="21.09" version="0.12.1+galaxy0">
+    <description>calculates AUCell to find relevant regulons/gene sets</description>
     <requirements>
         <container type="docker">
             aertslab/pyscenic:0.12.1

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -17,11 +17,11 @@
         #if $weights
            -w
         #end if
-           --num_workers \${GALAXY_SLOTS:-1}
+       --num_workers \${GALAXY_SLOTS:-1}
         #if $seed
            --seed "${seed}"
         #end if
-        #if $rank_threshold
+        #if str($rank_threshold):
            --rank_threshold "${rank_threshold}"
         #end if
         #if $auc_threshold
@@ -36,9 +36,7 @@
         #if $gene_attribute
            --gene_attribute "${gene_attribute}"
         #end if
-        #if $sparse
-           --sparse
-        #end if
+        $sparse
 
         && mv aucell.tsv "${output}"
     ]]></command>
@@ -54,7 +52,7 @@
       <param name="nes_threshold" type="float" label="NES Threshold" help="The Normalized Enrichment Score (NES) threshold for finding enriched features (default: 3.0)." optional="true" />
       <param name="cell_id_attribute" type="text" label="Cell ID Attribute" help="The name of the column attribute that specifies the identifiers of the cells in the loom file." optional="true" />
       <param name="gene_attribute" type="text" label="Gene Attribute" help="The name of the row attribute that specifies the gene symbols in the loom file." optional="true" />
-      <param name="sparse" type="boolean" label="Sparse Matrix" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only." optional="true" />
+      <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only." optional="true" />
     </inputs>
   
     <outputs>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -111,12 +111,42 @@ mv regulons.tsv '${output}'
             <output name="output" file="regulons.tsv" compare="sim_size" delta_frac="0.2"/>
         </test>
     </tests>
-    <help>
-        <![CDATA[
-            <p>This tool runs pyscenic ctx with the specified options.</p>
-            <!-- Add detailed help information for each parameter -->
-        ]]>
-    </help>
+    <help><![CDATA[
+        .. class:: infomark
+           :name: warning
+        
+           **pySCENIC ctx: Contextualize GRN**
+        
+        This tool refines gene regulatory networks (GRNs) by pruning targets that do not have an enrichment for a corresponding motif of the transcription factor (TF). This process effectively separates direct from indirect targets based on the presence of cis-regulatory footprints.
+        
+        **Inputs:**
+        
+        - **Module File**: A file containing the signature or co-expression modules. Supported formats include CSV, TSV (adjacencies), YAML, GMT, and DAT (modules).
+        - **Database Files**: One or more regulatory feature databases. Supported formats include feather or db (legacy).
+        - **Annotations File**: A file containing the motif annotations to use.
+        
+        **Optional Parameters:**
+        
+        - **No Pruning**: Do not perform pruning, i.e., find enriched motifs.
+        - **Chunk Size**: The size of the module chunks assigned to a node in the dask graph (default: 100).
+        - **Mode**: The mode to be used for computing (default: custom_multiprocessing).
+        - **All Modules**: Include positive and negative regulons in the analysis (default: only positive).
+        - **Transpose**: Transpose the expression matrix (rows=genes x columns=cells).
+        - **Rank Threshold**: The rank threshold used for deriving the target genes of an enriched motif (default: 5000).
+        - **AUC Threshold**: The threshold used for calculating the AUC of a feature as a fraction of ranked genes (default: 0.05).
+        - **NES Threshold**: The Normalized Enrichment Score (NES) threshold for finding enriched features (default: 3.0).
+        - **Min Orthologous Identity**: Minimum orthologous identity to use when annotating enriched motifs (default: 0.0).
+        - **Max Similarity FDR**: Maximum FDR in motif similarity to use when annotating enriched motifs (default: 0.001).
+        - **Thresholds**: The first method to create the TF-modules based on the best targets for each transcription factor (default: 0.75 0.90).
+        - **Top N Targets**: The second method is to select the top targets for a given TF (default: 50).
+        - **Top N Regulators**: The alternative way to create the TF-modules is to select the best regulators for each gene (default: 5 10 50).
+        - **Min Genes**: The minimum number of genes in a module (default: 20).
+        - **Expression Matrix File**: The name of the file that contains the expression matrix for the single-cell experiment. Supported formats include csv (rows=cells x columns=genes) or loom (rows=genes x columns=cells). Required if modules need to be generated.
+        - **Mask Dropouts**: Controls whether cell dropouts (cells in which expression of either TF or target gene is 0) are masked when calculating the correlation between a TF-target pair.
+        - **Cell ID Attribute**: The name of the column attribute that specifies the identifiers of the cells in the loom file.
+        - **Gene Attribute**: The name of the row attribute that specifies the gene symbols in the loom file.
+        - **Sparse**: If set, load the expression data as a sparse matrix. Currently applies to the GRN inference step only.
+        ]]></help>
     <citations>
         <citation type="doi">10.1038/nmeth.4463</citation>
     </citations>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -1,0 +1,124 @@
+<tool id="pyscenic_ctx" name="pyscenic ctx" profile="21.09" version="1.0.0">
+    <description>
+        computes active regulons based on a gene regulatory network
+    </description>
+    <requirements>
+        <container type="docker">
+            aertslab/pyscenic:0.12.1
+        </container>
+    </requirements>
+    <command><![CDATA[
+    PySCENIC_DB=db.genes_vs_motifs.rankings.feather &&
+    ln -s "${module_fname}" tf2targets.tsv &&
+    ln -s "${expression_mtx}" expr_mat.loom &&
+    ln -s "${database_fname}" \${PySCENIC_DB} &&
+
+    pyscenic ctx tf2targets.tsv \${PySCENIC_DB} 
+        --expression_mtx_fname expr_mat.loom
+    --output regulons.tsv
+#if $no_pruning
+    --no_pruning
+#end if
+#if $chunk_size
+    --chunk_size "${chunk_size}"
+#end if
+    --mode custom_multiprocessing
+    --num_workers \${GALAXY_SLOTS:-1}
+#if $all_modules
+    --all_modules
+#end if
+#if $transpose
+    --transpose
+#end if
+#if $rank_threshold
+    --rank_threshold "${rank_threshold}"
+#end if
+#if $auc_threshold
+    --auc_threshold "${auc_threshold}"
+#end if
+#if $nes_threshold
+    --nes_threshold "${nes_threshold}"
+#end if
+#if $min_orthologous_identity
+    --min_orthologous_identity "${min_orthologous_identity}"
+#end if
+#if $max_similarity_fdr
+    --max_similarity_fdr "${max_similarity_fdr}"
+#end if
+#if $annotations_fname
+    --annotations_fname "${annotations_fname}"
+#end if
+#if $thresholds
+    --thresholds "${thresholds}"
+#end if
+#if $top_n_targets
+    --top_n_targets "${top_n_targets}"
+#end if
+#if $top_n_regulators
+    --top_n_regulators "${top_n_regulators}"
+#end if
+#if $min_genes
+    --min_genes "${min_genes}"
+#end if
+#if $mask_dropouts
+    --mask_dropouts
+#end if
+#if $cell_id_attribute
+    --cell_id_attribute "${cell_id_attribute}"
+#end if
+#if $gene_attribute
+    --gene_attribute "${gene_attribute}"
+#end if
+#if $sparse
+    --sparse
+#end if
+&&
+
+mv regulons.tsv "${output}"
+]]></command>
+    <inputs>
+        <param type="data" name="module_fname" format="tabular" label="Module File" help="Signatures or the co-expression modules. Usually the output from pyscenic grn." />
+        <param type="data" name="database_fname" label="Database File" help="Regulatory feature databases. Supported formats: feather" />
+        <param type="data" name="annotations_fname" format="tabular" label="Annotations File" help="File that contains the motif annotations to use." />
+        <param type="data" name="expression_mtx" format="loom" label="Expression Matrix" help="The expression matrix for the single cell experiment." />
+        <param type="boolean" name="no_pruning" label="No Pruning" optional="true" help="Do not perform pruning, i.e. find enriched motifs." />
+        <param type="integer" name="chunk_size" label="Chunk Size" optional="true" help="The size of the module chunks assigned to a node in the dask graph (default: 100)." />
+        <param type="boolean" name="all_modules" label="All Modules" optional="true" help="Include positive and negative regulons in the analysis (default: no, i.e. only positive)." />
+        <param type="boolean" name="transpose" label="Transpose" optional="true" help="Transpose the expression matrix (rows=genes x columns=cells)." />
+        <param type="float" name="rank_threshold" label="Rank Threshold" optional="true" help="The rank threshold used for deriving the target genes of an enriched motif." />
+        <param type="float" name="auc_threshold" label="AUC Threshold" optional="true" help="The threshold used for calculating the AUC of a feature as fraction of ranked genes." />
+        <param type="float" name="nes_threshold" label="NES Threshold" optional="true" help="The Normalized Enrichment Score (NES) threshold for finding enriched features." />
+        <param type="float" name="min_orthologous_identity" label="Minimum Orthologous Identity" optional="true" help="Minimum orthologous identity to use when annotating enriched motifs." />
+        <param type="float" name="max_similarity_fdr" label="Maximum Similarity FDR" optional="true" help="Maximum FDR in motif similarity to use when annotating enriched motifs." />
+        <param type="text" name="thresholds" label="Thresholds" optional="true" help="Thresholds to use for selecting the features (e.g., motifs)." />
+        <param type="integer" name="top_n_targets" label="Top N Targets" optional="true" help="The number of top targets to retain for each feature." />
+        <param type="integer" name="top_n_regulators" label="Top N Regulators" optional="true" help="The number of top regulators to retain for each feature." />
+        <param type="integer" name="min_genes" label="Minimum Genes" optional="true" help="The minimum number of genes a module needs to have to be considered for regulatory network analysis." />
+        <param type="boolean" name="mask_dropouts" label="Mask Dropouts" optional="true" help="Mask dropouts in the expression matrix." />
+        <param type="text" name="cell_id_attribute" label="Cell ID Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains cell IDs." />
+        <param type="text" name="gene_attribute" label="Gene Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains gene names." />
+        <param type="boolean" name="sparse" label="Sparse" optional="true" help="Use a sparse matrix for the gene regulatory network inference step." />
+    </inputs>
+    <outputs>
+        <data name="output" format="tabular" label="${tool.name} on ${on_string}: table of enriched motifs and target genes"/>
+        <!-- Define other output formats as needed -->
+    </outputs>
+    <tests>
+        <test expect_num_outputs="1">
+            <param name="module_fname" value="tf2targets.tsv"/>
+            <param name="expression_mtx" value="expr_mat.loom"/>
+            <param name="database_fname" value="genome-ranking_v2.feather"/>
+            <param name="annotations_fname" value="motifs.tbl"/>
+            <output name="output" file="regulons.tsv" compare="sim_size" delta_frac="0.2"/>
+        </test>
+    </tests>
+    <help>
+        <![CDATA[
+            <p>This tool runs pyscenic ctx with the specified options.</p>
+            <!-- Add detailed help information for each parameter -->
+        ]]>
+    </help>
+    <citations>
+        <citation type="doi">10.1038/nmeth.4463</citation>
+    </citations>
+</tool>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -9,9 +9,9 @@
     </requirements>
     <command><![CDATA[
     PySCENIC_DB=db.genes_vs_motifs.rankings.feather &&
-    ln -s "${module_fname}" tf2targets.tsv &&
-    ln -s "${expression_mtx}" expr_mat.loom &&
-    ln -s "${database_fname}" \${PySCENIC_DB} &&
+    ln -s '${module_fname}' tf2targets.tsv &&
+    ln -s '${expression_mtx}' expr_mat.loom &&
+    ln -s '${database_fname}' \${PySCENIC_DB} &&
 
     pyscenic ctx tf2targets.tsv \${PySCENIC_DB} 
         --expression_mtx_fname expr_mat.loom
@@ -20,7 +20,7 @@
     --no_pruning
 #end if
 #if $chunk_size
-    --chunk_size "${chunk_size}"
+    --chunk_size '${chunk_size}'
 #end if
     --mode custom_multiprocessing
     --num_workers \${GALAXY_SLOTS:-1}
@@ -31,73 +31,73 @@
     --transpose
 #end if
 #if $rank_threshold
-    --rank_threshold "${rank_threshold}"
+    --rank_threshold '${rank_threshold}'
 #end if
 #if $auc_threshold
-    --auc_threshold "${auc_threshold}"
+    --auc_threshold '${auc_threshold}'
 #end if
 #if $nes_threshold
-    --nes_threshold "${nes_threshold}"
+    --nes_threshold '${nes_threshold}'
 #end if
 #if $min_orthologous_identity
-    --min_orthologous_identity "${min_orthologous_identity}"
+    --min_orthologous_identity '${min_orthologous_identity}'
 #end if
 #if $max_similarity_fdr
-    --max_similarity_fdr "${max_similarity_fdr}"
+    --max_similarity_fdr '${max_similarity_fdr}'
 #end if
 #if $annotations_fname
-    --annotations_fname "${annotations_fname}"
+    --annotations_fname '${annotations_fname}'
 #end if
 #if $thresholds
-    --thresholds "${thresholds}"
+    --thresholds '${thresholds}'
 #end if
 #if $top_n_targets
-    --top_n_targets "${top_n_targets}"
+    --top_n_targets '${top_n_targets}'
 #end if
 #if $top_n_regulators
-    --top_n_regulators "${top_n_regulators}"
+    --top_n_regulators '${top_n_regulators}'
 #end if
 #if $min_genes
-    --min_genes "${min_genes}"
+    --min_genes '${min_genes}'
 #end if
 #if $mask_dropouts
     --mask_dropouts
 #end if
 #if $cell_id_attribute
-    --cell_id_attribute "${cell_id_attribute}"
+    --cell_id_attribute '${cell_id_attribute}'
 #end if
 #if $gene_attribute
-    --gene_attribute "${gene_attribute}"
+    --gene_attribute '${gene_attribute}'
 #end if
 #if $sparse
     --sparse
 #end if
 &&
 
-mv regulons.tsv "${output}"
+mv regulons.tsv '${output}'
 ]]></command>
     <inputs>
-        <param type="data" name="module_fname" format="tabular" label="Module File" help="Signatures or the co-expression modules. Usually the output from pyscenic grn." />
-        <param type="data" name="database_fname" label="Database File" help="Regulatory feature databases. Supported formats: feather" />
-        <param type="data" name="annotations_fname" format="tabular" label="Annotations File" help="File that contains the motif annotations to use." />
-        <param type="data" name="expression_mtx" format="loom" label="Expression Matrix" help="The expression matrix for the single cell experiment." />
-        <param type="boolean" name="no_pruning" label="No Pruning" optional="true" help="Do not perform pruning, i.e. find enriched motifs." />
-        <param type="integer" name="chunk_size" label="Chunk Size" optional="true" help="The size of the module chunks assigned to a node in the dask graph (default: 100)." />
-        <param type="boolean" name="all_modules" label="All Modules" optional="true" help="Include positive and negative regulons in the analysis (default: no, i.e. only positive)." />
-        <param type="boolean" name="transpose" label="Transpose" optional="true" help="Transpose the expression matrix (rows=genes x columns=cells)." />
-        <param type="float" name="rank_threshold" label="Rank Threshold" optional="true" help="The rank threshold used for deriving the target genes of an enriched motif." />
-        <param type="float" name="auc_threshold" label="AUC Threshold" optional="true" help="The threshold used for calculating the AUC of a feature as fraction of ranked genes." />
-        <param type="float" name="nes_threshold" label="NES Threshold" optional="true" help="The Normalized Enrichment Score (NES) threshold for finding enriched features." />
-        <param type="float" name="min_orthologous_identity" label="Minimum Orthologous Identity" optional="true" help="Minimum orthologous identity to use when annotating enriched motifs." />
-        <param type="float" name="max_similarity_fdr" label="Maximum Similarity FDR" optional="true" help="Maximum FDR in motif similarity to use when annotating enriched motifs." />
-        <param type="text" name="thresholds" label="Thresholds" optional="true" help="Thresholds to use for selecting the features (e.g., motifs)." />
-        <param type="integer" name="top_n_targets" label="Top N Targets" optional="true" help="The number of top targets to retain for each feature." />
-        <param type="integer" name="top_n_regulators" label="Top N Regulators" optional="true" help="The number of top regulators to retain for each feature." />
-        <param type="integer" name="min_genes" label="Minimum Genes" optional="true" help="The minimum number of genes a module needs to have to be considered for regulatory network analysis." />
-        <param type="boolean" name="mask_dropouts" label="Mask Dropouts" optional="true" help="Mask dropouts in the expression matrix." />
-        <param type="text" name="cell_id_attribute" label="Cell ID Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains cell IDs." />
-        <param type="text" name="gene_attribute" label="Gene Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains gene names." />
-        <param type="boolean" name="sparse" label="Sparse" optional="true" help="Use a sparse matrix for the gene regulatory network inference step." />
+        <param type="data" name="module_fname" format="tabular" label="Module File" help="Signatures or the co-expression modules. Usually the output from pyscenic grn."/>
+        <param type="data" name="database_fname" label="Database File" help="Regulatory feature databases. Supported formats: feather"/>
+        <param type="data" name="annotations_fname" format="tabular" label="Annotations File" help="File that contains the motif annotations to use."/>
+        <param type="data" name="expression_mtx" format="loom" label="Expression Matrix" help="The expression matrix for the single cell experiment."/>
+        <param type="boolean" name="no_pruning" label="No Pruning" optional="true" help="Do not perform pruning, i.e. find enriched motifs."/>
+        <param type="integer" name="chunk_size" label="Chunk Size" optional="true" help="The size of the module chunks assigned to a node in the dask graph (default: 100)."/>
+        <param type="boolean" name="all_modules" label="All Modules" optional="true" help="Include positive and negative regulons in the analysis (default: no, i.e. only positive)."/>
+        <param type="boolean" name="transpose" label="Transpose" optional="true" help="Transpose the expression matrix (rows=genes x columns=cells)."/>
+        <param type="float" name="rank_threshold" label="Rank Threshold" optional="true" help="The rank threshold used for deriving the target genes of an enriched motif."/>
+        <param type="float" name="auc_threshold" label="AUC Threshold" optional="true" help="The threshold used for calculating the AUC of a feature as fraction of ranked genes."/>
+        <param type="float" name="nes_threshold" label="NES Threshold" optional="true" help="The Normalized Enrichment Score (NES) threshold for finding enriched features."/>
+        <param type="float" name="min_orthologous_identity" label="Minimum Orthologous Identity" optional="true" help="Minimum orthologous identity to use when annotating enriched motifs."/>
+        <param type="float" name="max_similarity_fdr" label="Maximum Similarity FDR" optional="true" help="Maximum FDR in motif similarity to use when annotating enriched motifs."/>
+        <param type="text" name="thresholds" label="Thresholds" optional="true" help="Thresholds to use for selecting the features (e.g., motifs)."/>
+        <param type="integer" name="top_n_targets" label="Top N Targets" optional="true" help="The number of top targets to retain for each feature."/>
+        <param type="integer" name="top_n_regulators" label="Top N Regulators" optional="true" help="The number of top regulators to retain for each feature."/>
+        <param type="integer" name="min_genes" label="Minimum Genes" optional="true" help="The minimum number of genes a module needs to have to be considered for regulatory network analysis."/>
+        <param type="boolean" name="mask_dropouts" label="Mask Dropouts" optional="true" help="Mask dropouts in the expression matrix."/>
+        <param type="text" name="cell_id_attribute" label="Cell ID Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains cell IDs."/>
+        <param type="text" name="gene_attribute" label="Gene Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains gene names."/>
+        <param type="boolean" name="sparse" label="Sparse" optional="true" help="Use a sparse matrix for the gene regulatory network inference step."/>
     </inputs>
     <outputs>
         <data name="output" format="tabular" label="${tool.name} on ${on_string}: table of enriched motifs and target genes"/>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -7,7 +7,7 @@
     </macros>
     <expand macro="requirements"/>
     <command><![CDATA[
-    #set PySCENIC_DB = db.genes_vs_motifs.rankings.feather
+    #set PySCENIC_DB = "db.genes_vs_motifs.rankings.feather"
     ln -s '${module_fname}' tf2targets.tsv &&
     ln -s '${expression_mtx}' expr_mat.loom &&
     ln -s '${database_fname}' ${PySCENIC_DB} &&

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -1,4 +1,4 @@
-<tool id="pyscenic_ctx" name="pyscenic ctx" profile="21.09" version="1.0.0">
+<tool id="pyscenic_ctx" name="PySCENIC CTX" profile="21.09" version="0.12.1+galaxy0">
     <description>
         computes active regulons based on a gene regulatory network
     </description>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -7,12 +7,12 @@
     </macros>
     <expand macro="requirements"/>
     <command><![CDATA[
-    PySCENIC_DB=db.genes_vs_motifs.rankings.feather &&
+    #set PySCENIC_DB = db.genes_vs_motifs.rankings.feather
     ln -s '${module_fname}' tf2targets.tsv &&
     ln -s '${expression_mtx}' expr_mat.loom &&
-    ln -s '${database_fname}' \${PySCENIC_DB} &&
+    ln -s '${database_fname}' ${PySCENIC_DB} &&
 
-    pyscenic ctx tf2targets.tsv \${PySCENIC_DB} 
+    pyscenic ctx tf2targets.tsv ${PySCENIC_DB} 
         --expression_mtx_fname expr_mat.loom
     --output regulons.tsv
 $no_pruning
@@ -62,9 +62,6 @@ $mask_dropouts
 #end if
 $sparse
 
-&&
-
-mv regulons.tsv '${output}'
 ]]></command>
     <inputs>
         <param type="data" name="module_fname" format="tabular" label="Module File" help="Signatures or the co-expression modules. Usually the output from pyscenic grn."/>
@@ -90,7 +87,7 @@ mv regulons.tsv '${output}'
         <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only."/>
     </inputs>
     <outputs>
-        <data name="output" format="tabular" label="${tool.name} on ${on_string}: table of enriched motifs and target genes"/>
+        <data name="output" format="tabular" from_work_dir="regulons.tsv" label="${tool.name} on ${on_string}: table of enriched motifs and target genes"/>
         <!-- Define other output formats as needed -->
     </outputs>
     <tests>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -15,20 +15,14 @@
     pyscenic ctx tf2targets.tsv \${PySCENIC_DB} 
         --expression_mtx_fname expr_mat.loom
     --output regulons.tsv
-#if $no_pruning
-    --no_pruning
-#end if
+$no_pruning
 #if $chunk_size
     --chunk_size '${chunk_size}'
 #end if
     --mode custom_multiprocessing
     --num_workers \${GALAXY_SLOTS:-1}
-#if $all_modules
-    --all_modules
-#end if
-#if $transpose
-    --transpose
-#end if
+$all_modules
+$transpose
 #if $rank_threshold
     --rank_threshold '${rank_threshold}'
 #end if
@@ -59,9 +53,7 @@
 #if $min_genes
     --min_genes '${min_genes}'
 #end if
-#if $mask_dropouts
-    --mask_dropouts
-#end if
+$mask_dropouts
 #if $cell_id_attribute
     --cell_id_attribute '${cell_id_attribute}'
 #end if
@@ -79,10 +71,10 @@ mv regulons.tsv '${output}'
         <param type="data" name="database_fname" label="Database File" help="Regulatory feature databases. Supported formats: feather"/>
         <param type="data" name="annotations_fname" format="tabular" label="Annotations File" help="File that contains the motif annotations to use."/>
         <param type="data" name="expression_mtx" format="loom" label="Expression Matrix" help="The expression matrix for the single cell experiment."/>
-        <param type="boolean" name="no_pruning" label="No Pruning" optional="true" help="Do not perform pruning, i.e. find enriched motifs."/>
+        <param type="boolean" name="no_pruning" label="No Pruning" truevalue="--no_pruning" falsevalue="" help="Do not perform pruning, i.e. find enriched motifs."/>
         <param type="integer" name="chunk_size" label="Chunk Size" optional="true" help="The size of the module chunks assigned to a node in the dask graph (default: 100)."/>
-        <param type="boolean" name="all_modules" label="All Modules" optional="true" help="Include positive and negative regulons in the analysis (default: no, i.e. only positive)."/>
-        <param type="boolean" name="transpose" label="Transpose" optional="true" help="Transpose the expression matrix (rows=genes x columns=cells)."/>
+        <param type="boolean" name="all_modules" label="All Modules" truevalue="--all_modules" falsevalue="" help="Include positive and negative regulons in the analysis (default: no, i.e. only positive)."/>
+        <param type="boolean" name="transpose" label="Transpose Expression Matrix" truevalue="-t" falsevalue="" help="Use this if the matrix is cell x genes instead of genes x cells as expected"/>
         <param type="float" name="rank_threshold" label="Rank Threshold" optional="true" help="The rank threshold used for deriving the target genes of an enriched motif."/>
         <param type="float" name="auc_threshold" label="AUC Threshold" optional="true" help="The threshold used for calculating the AUC of a feature as fraction of ranked genes."/>
         <param type="float" name="nes_threshold" label="NES Threshold" optional="true" help="The Normalized Enrichment Score (NES) threshold for finding enriched features."/>
@@ -92,7 +84,7 @@ mv regulons.tsv '${output}'
         <param type="integer" name="top_n_targets" label="Top N Targets" optional="true" help="The number of top targets to retain for each feature."/>
         <param type="integer" name="top_n_regulators" label="Top N Regulators" optional="true" help="The number of top regulators to retain for each feature."/>
         <param type="integer" name="min_genes" label="Minimum Genes" optional="true" help="The minimum number of genes a module needs to have to be considered for regulatory network analysis."/>
-        <param type="boolean" name="mask_dropouts" label="Mask Dropouts" optional="true" help="Mask dropouts in the expression matrix."/>
+        <param type="boolean" name="mask_dropouts" label="Mask Dropouts" truevalue="--mask_dropouts" falsevalue="" help="Mask dropouts in the expression matrix."/>
         <param type="text" name="cell_id_attribute" label="Cell ID Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains cell IDs."/>
         <param type="text" name="gene_attribute" label="Gene Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains gene names."/>
         <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only."/>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -2,11 +2,10 @@
     <description>
         computes active regulons based on a gene regulatory network
     </description>
-    <requirements>
-        <container type="docker">
-            aertslab/pyscenic:0.12.1
-        </container>
-    </requirements>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
     <command><![CDATA[
     PySCENIC_DB=db.genes_vs_motifs.rankings.feather &&
     ln -s '${module_fname}' tf2targets.tsv &&
@@ -147,7 +146,5 @@ mv regulons.tsv '${output}'
         - **Gene Attribute**: The name of the row attribute that specifies the gene symbols in the loom file.
         - **Sparse**: If set, load the expression data as a sparse matrix. Currently applies to the GRN inference step only.
         ]]></help>
-    <citations>
-        <citation type="doi">10.1038/nmeth.4463</citation>
-    </citations>
+    <expand macro="citations"/>
 </tool>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -69,9 +69,8 @@
 #if $gene_attribute
     --gene_attribute '${gene_attribute}'
 #end if
-#if $sparse
-    --sparse
-#end if
+$sparse
+
 &&
 
 mv regulons.tsv '${output}'
@@ -97,7 +96,7 @@ mv regulons.tsv '${output}'
         <param type="boolean" name="mask_dropouts" label="Mask Dropouts" optional="true" help="Mask dropouts in the expression matrix."/>
         <param type="text" name="cell_id_attribute" label="Cell ID Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains cell IDs."/>
         <param type="text" name="gene_attribute" label="Gene Attribute" optional="true" help="The name of the attribute in the loom expression matrix that contains gene names."/>
-        <param type="boolean" name="sparse" label="Sparse" optional="true" help="Use a sparse matrix for the gene regulatory network inference step."/>
+        <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only."/>
     </inputs>
     <outputs>
         <data name="output" format="tabular" label="${tool.name} on ${on_string}: table of enriched motifs and target genes"/>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -1,4 +1,4 @@
-<tool id="pyscenic_ctx" name="PySCENIC CTX" profile="21.09" version="0.12.1+galaxy0">
+<tool id="pyscenic_ctx" name="PySCENIC CTX" profile="21.09" version="@TOOL_VERSION@+galaxy0">
     <description>
         computes active regulons based on a gene regulatory network
     </description>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -1,4 +1,4 @@
-<tool id="pyscenic_grn" name="PySCENIC GRN" version="0.12.1+galaxy0" profile="21.09">
+<tool id="pyscenic_grn" name="PySCENIC GRN" version="@TOOL_VERSION@+galaxy0" profile="21.09">
     <description>infers gene regulatory networks</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -14,9 +14,7 @@
                 pyscenic grn 
             #end if
             -o tf2targets.tsv
-            #if $transpose
-            -t
-            #end if
+            $transpose
             #if $method
             -m '${method}'
             #end if
@@ -40,7 +38,7 @@
         <param name="expression_mtx" type="data" format="loom" label="Expression Matrix Loom File" help="In format rows=genes x columns=cells"/>
         <param name="tfs_fname" type="data" format="txt" label="Transcription Factors File" help="Simple text file, one transcription factor symbol per line"/>
         <param name="use_arboretum" type="boolean" label="Use arboretum" checked="false" help="Uses the arboretum approach instead of pyscenic grn call, which can be better for multi processing"/>
-        <param name="transpose" type="boolean" default_value="false" label="Transpose Expression Matrix" help="Use this if the matrix is cell x genes instead of genes x cells as expected"/>
+        <param name="transpose" type="boolean" truevalue="-t" falsevalue="" label="Transpose Expression Matrix" help="Use this if the matrix is cell x genes instead of genes x cells as expected"/>
         <param name="method" type="select" label="Method">
             <option value="genie3">GENIE3</option>
             <option value="grnboost2" selected="true">GRNBoost2</option>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -49,7 +49,7 @@
         <param name="seed" type="integer" optional="true" label="Seed"/>
     </inputs>
     <outputs>
-        <data name="tf2targets" format="tsv" label="${tool.name} on ${on_string}: gene regulatory network"/>
+        <data name="tf2targets" format="tabular" label="${tool.name} on ${on_string}: gene regulatory network"/>
     </outputs>
     <tests>
         <test expect_num_outputs="1">
@@ -67,7 +67,7 @@
             <param name="tfs_fname" value="allTFs_hg38.txt"/>
             <param name="use_arboretum" value="true"/>
             <param name="seed" value="1"/>
-            <output name="tf2targets">
+            <output name="tf2targets" ftype="tabular">
                 <assert_contents>
                     <has_n_lines n="1006973"/>
                 </assert_contents>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -1,5 +1,5 @@
-<tool id="pyscenic_grn" name="pyscenic grn" version="0.12.1+galaxy0" profile="21.09">
-    <description>Gene regulatory network inference using pyscenic</description>
+<tool id="pyscenic_grn" name="PySCENIC GRN" version="0.12.1+galaxy0" profile="21.09">
+    <description>Gene regulatory network inference using PySCENIC</description>
     <requirements>
         <container type="docker">
             aertslab/pyscenic:0.12.1

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -1,0 +1,89 @@
+<tool id="pyscenic_grn" name="pyscenic grn" version="1.0.0" profile="21.09">
+    <description>Gene regulatory network inference using pyscenic</description>
+    <requirements>
+        <container type="docker">
+            aertslab/pyscenic:0.12.1
+        </container>
+    </requirements>
+    <command>
+        <![CDATA[
+        ln -s ${expression_mtx} expr_mat.loom && 
+        ln -s ${tfs_fname} tfs.txt &&
+        pyscenic grn 
+            -o tf2targets.tsv
+            #if $transpose
+            -t
+            #end if
+            #if $method
+            -m "${method}"
+            #end if
+            #if $seed
+            --seed "${seed}"
+            #end if
+            --num_workers \${GALAXY_SLOTS:-1}
+            #if $cell_id_attribute
+            --cell_id_attribute "${cell_id_attribute}"
+            #end if
+            #if $gene_attribute
+            --gene_attribute "${gene_attribute}"
+            #end if
+            #if $sparse
+            --sparse
+            #end if
+            expr_mat.loom tfs.txt &&
+            mv tf2targets.tsv '${tf2targets}'
+        ]]>
+    </command>
+    <inputs>
+        <param name="expression_mtx" type="data" format="loom" label="Expression Matrix Loom File" help="In format rows=genes x columns=cells" />
+        <param name="tfs_fname" type="data" format="txt" label="Transcription Factors File" help="Simple text file, one transcription factor symbol per line"/>
+        <param name="transpose" type="boolean" default_value="false" label="Transpose Expression Matrix" />
+        <param name="method" type="select" label="Method">
+            <option value="genie3">GENIE3</option>
+            <option value="grnboost2" selected="true">GRNBoost2</option>
+        </param>
+        <param name="cell_id_attribute" type="text" optional="true" label="Cell ID Attribute" />
+        <param name="gene_attribute" type="text" optional="true" label="Gene Attribute" />
+        <param name="sparse" type="boolean" optional="true" label="Load as Sparse Matrix" />
+        <param name="seed" type="integer" optional="true" label="Seed" />
+    </inputs>
+    <outputs>
+        <data name="tf2targets" format="tsv" label="${tool.name} on ${on_string}: gene regulatory network"/>
+    </outputs>
+    <tests>
+        <test expect_num_outputs="1">
+            <param name="expression_mtx" value="expr_mat.loom"/>
+            <param name="tfs_fname" value="allTFs_hg38.txt"/>
+            <param name="seed" value="1"/>
+            <output name="tf2targets" > <!-- file="tf2targets.tsv" compare="sim_size" delta_frac="0.2"/> -->
+                <assert_contents>
+                    <has_n_lines n="1006973"/>
+                </assert_contents>
+            </output>
+        </test>
+
+    </tests>
+    <help><![CDATA[
+        This tool runs the `pyscenic grn` command to infer gene regulatory networks.
+
+        **Inputs:**
+
+        - Expression Matrix File: Loom file containing the expression matrix, (rows=genes x columns=cells)
+        - Transcription Factors File: TXT file with a list of transcription factors.
+        
+        **Options:**
+
+        - Output File: Path to the output file (CSV format).
+        - Transpose Expression Matrix: If selected, transpose the expression matrix.
+        - Method: Algorithm for gene regulatory network reconstruction (default: GRNBoost2).
+        - Seed: Seed value for random state initialization.
+        - Number of Workers: Number of workers to use for computation.
+        - Client or Address: Client or IP address of the dask scheduler.
+        - Cell ID Attribute: Column attribute for cell identifiers in the loom file.
+        - Gene Attribute: Row attribute for gene symbols in the loom file.
+        - Load as Sparse Matrix: Load the expression data as a sparse matrix.
+    ]]></help>
+    <citations>
+        <citation type="doi">10.1038/nmeth.4463</citation>
+    </citations>
+</tool>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -1,5 +1,5 @@
 <tool id="pyscenic_grn" name="PySCENIC GRN" version="0.12.1+galaxy0" profile="21.09">
-    <description>Gene regulatory network inference using PySCENIC</description>
+    <description>infers gene regulatory networks</description>
     <requirements>
         <container type="docker">
             aertslab/pyscenic:0.12.1
@@ -7,9 +7,13 @@
     </requirements>
     <command detect_errors="exit_code">
         <![CDATA[
-        ln -s '${expression_mtx}' expr_mat.loom && 
-        ln -s '${tfs_fname}' tfs.txt &&
-        pyscenic grn 
+            ln -s '${expression_mtx}' expr_mat.loom && 
+            ln -s '${tfs_fname}' tfs.txt &&
+            #if $use_arboretum
+                arboreto_with_multiprocessing.py
+            #else
+                pyscenic grn 
+            #end if
             -o tf2targets.tsv
             #if $transpose
             -t
@@ -27,9 +31,8 @@
             #if $gene_attribute
             --gene_attribute '${gene_attribute}'
             #end if
-            #if $sparse
-            --sparse
-            #end if
+            $sparse
+            
             expr_mat.loom tfs.txt &&
             mv tf2targets.tsv '${tf2targets}'
         ]]>
@@ -37,14 +40,15 @@
     <inputs>
         <param name="expression_mtx" type="data" format="loom" label="Expression Matrix Loom File" help="In format rows=genes x columns=cells"/>
         <param name="tfs_fname" type="data" format="txt" label="Transcription Factors File" help="Simple text file, one transcription factor symbol per line"/>
-        <param name="transpose" type="boolean" default_value="false" label="Transpose Expression Matrix"/>
+        <param name="use_arboretum" type="boolean" label="Use arboretum" checked="false" help="Uses the arboretum approach instead of pyscenic grn call, which can be better for multi processing"/>
+        <param name="transpose" type="boolean" default_value="false" label="Transpose Expression Matrix" help="Use this if the matrix is cell x genes instead of genes x cells as expected"/>
         <param name="method" type="select" label="Method">
             <option value="genie3">GENIE3</option>
             <option value="grnboost2" selected="true">GRNBoost2</option>
         </param>
         <param name="cell_id_attribute" type="text" optional="true" label="Cell ID Attribute"/>
         <param name="gene_attribute" type="text" optional="true" label="Gene Attribute"/>
-        <param name="sparse" type="boolean" optional="true" label="Load as Sparse Matrix"/>
+        <param name="sparse" type="boolean" label="Sparse Matrix" truevalue="--sparse" falsevalue="" help="If set, load the expression data as a sparse matrix. Currently applies to the grn inference step only."/>
         <param name="seed" type="integer" optional="true" label="Seed"/>
     </inputs>
     <outputs>
@@ -56,6 +60,18 @@
             <param name="tfs_fname" value="allTFs_hg38.txt"/>
             <param name="seed" value="1"/>
             <output name="tf2targets">
+                <!-- file="tf2targets.tsv" compare="sim_size" delta_frac="0.2"/> -->
+                <assert_contents>
+                    <has_n_lines n="1006973"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="expression_mtx" value="expr_mat.loom"/>
+            <param name="tfs_fname" value="allTFs_hg38.txt"/>
+            <param name="use_arboretum" value="true"/>
+            <param name="seed" value="1"/>
+            <output name="tf2targets" file="tf2targets_arboretum.tsv" compare="sim_size" delta_frac="0.2">
                 <!-- file="tf2targets.tsv" compare="sim_size" delta_frac="0.2"/> -->
                 <assert_contents>
                     <has_n_lines n="1006973"/>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -1,11 +1,11 @@
-<tool id="pyscenic_grn" name="pyscenic grn" version="1.0.0" profile="21.09">
+<tool id="pyscenic_grn" name="pyscenic grn" version="0.12.1+galaxy0" profile="21.09">
     <description>Gene regulatory network inference using pyscenic</description>
     <requirements>
         <container type="docker">
             aertslab/pyscenic:0.12.1
         </container>
     </requirements>
-    <command>
+    <command detect_errors="exit_code">
         <![CDATA[
         ln -s ${expression_mtx} expr_mat.loom && 
         ln -s ${tfs_fname} tfs.txt &&

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -60,7 +60,6 @@
             <param name="tfs_fname" value="allTFs_hg38.txt"/>
             <param name="seed" value="1"/>
             <output name="tf2targets">
-                <!-- file="tf2targets.tsv" compare="sim_size" delta_frac="0.2"/> -->
                 <assert_contents>
                     <has_n_lines n="1006973"/>
                 </assert_contents>
@@ -71,8 +70,7 @@
             <param name="tfs_fname" value="allTFs_hg38.txt"/>
             <param name="use_arboretum" value="true"/>
             <param name="seed" value="1"/>
-            <output name="tf2targets" file="tf2targets_arboretum.tsv" compare="sim_size" delta_frac="0.2">
-                <!-- file="tf2targets.tsv" compare="sim_size" delta_frac="0.2"/> -->
+            <output name="tf2targets">
                 <assert_contents>
                     <has_n_lines n="1006973"/>
                 </assert_contents>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -7,25 +7,25 @@
     </requirements>
     <command detect_errors="exit_code">
         <![CDATA[
-        ln -s ${expression_mtx} expr_mat.loom && 
-        ln -s ${tfs_fname} tfs.txt &&
+        ln -s '${expression_mtx}' expr_mat.loom && 
+        ln -s '${tfs_fname}' tfs.txt &&
         pyscenic grn 
             -o tf2targets.tsv
             #if $transpose
             -t
             #end if
             #if $method
-            -m "${method}"
+            -m '${method}'
             #end if
             #if $seed
-            --seed "${seed}"
+            --seed '${seed}'
             #end if
             --num_workers \${GALAXY_SLOTS:-1}
             #if $cell_id_attribute
-            --cell_id_attribute "${cell_id_attribute}"
+            --cell_id_attribute '${cell_id_attribute}'
             #end if
             #if $gene_attribute
-            --gene_attribute "${gene_attribute}"
+            --gene_attribute '${gene_attribute}'
             #end if
             #if $sparse
             --sparse
@@ -35,17 +35,17 @@
         ]]>
     </command>
     <inputs>
-        <param name="expression_mtx" type="data" format="loom" label="Expression Matrix Loom File" help="In format rows=genes x columns=cells" />
+        <param name="expression_mtx" type="data" format="loom" label="Expression Matrix Loom File" help="In format rows=genes x columns=cells"/>
         <param name="tfs_fname" type="data" format="txt" label="Transcription Factors File" help="Simple text file, one transcription factor symbol per line"/>
-        <param name="transpose" type="boolean" default_value="false" label="Transpose Expression Matrix" />
+        <param name="transpose" type="boolean" default_value="false" label="Transpose Expression Matrix"/>
         <param name="method" type="select" label="Method">
             <option value="genie3">GENIE3</option>
             <option value="grnboost2" selected="true">GRNBoost2</option>
         </param>
-        <param name="cell_id_attribute" type="text" optional="true" label="Cell ID Attribute" />
-        <param name="gene_attribute" type="text" optional="true" label="Gene Attribute" />
-        <param name="sparse" type="boolean" optional="true" label="Load as Sparse Matrix" />
-        <param name="seed" type="integer" optional="true" label="Seed" />
+        <param name="cell_id_attribute" type="text" optional="true" label="Cell ID Attribute"/>
+        <param name="gene_attribute" type="text" optional="true" label="Gene Attribute"/>
+        <param name="sparse" type="boolean" optional="true" label="Load as Sparse Matrix"/>
+        <param name="seed" type="integer" optional="true" label="Seed"/>
     </inputs>
     <outputs>
         <data name="tf2targets" format="tsv" label="${tool.name} on ${on_string}: gene regulatory network"/>
@@ -55,13 +55,13 @@
             <param name="expression_mtx" value="expr_mat.loom"/>
             <param name="tfs_fname" value="allTFs_hg38.txt"/>
             <param name="seed" value="1"/>
-            <output name="tf2targets" > <!-- file="tf2targets.tsv" compare="sim_size" delta_frac="0.2"/> -->
+            <output name="tf2targets">
+                <!-- file="tf2targets.tsv" compare="sim_size" delta_frac="0.2"/> -->
                 <assert_contents>
                     <has_n_lines n="1006973"/>
                 </assert_contents>
             </output>
         </test>
-
     </tests>
     <help><![CDATA[
         This tool runs the `pyscenic grn` command to infer gene regulatory networks.

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -1,10 +1,9 @@
 <tool id="pyscenic_grn" name="PySCENIC GRN" version="0.12.1+galaxy0" profile="21.09">
     <description>infers gene regulatory networks</description>
-    <requirements>
-        <container type="docker">
-            aertslab/pyscenic:0.12.1
-        </container>
-    </requirements>
+    <macros>
+        <import>macros.xml</import>
+    </macros>
+    <expand macro="requirements"/>
     <command detect_errors="exit_code">
         <![CDATA[
             ln -s '${expression_mtx}' expr_mat.loom && 
@@ -97,7 +96,5 @@
         - Gene Attribute: Row attribute for gene symbols in the loom file.
         - Load as Sparse Matrix: Load the expression data as a sparse matrix.
     ]]></help>
-    <citations>
-        <citation type="doi">10.1038/nmeth.4463</citation>
-    </citations>
+    <expand macro="citations"/>
 </tool>


### PR DESCRIPTION
# Description

Adds the PySCENIC wrappers for grn, ctx and aucell.

- [x] grn
- [x] ctx
- [x] aucell
- [x] Add test data to Zenodo and update get data logic.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [x] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
