### PR TITLE
Reinstate handle of failed genesets decoupler_aucell_score.py

### DIFF
--- a/tools/tertiary-analysis/decoupler/decoupler_aucell_score.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_aucell_score.py
@@ -136,14 +136,17 @@ def score_genes_aucell_mt(
         gene_set_gene["gene"] = gene_set_gene["gene_id"]
 
     # run decoupler's run_aucell
-    dc.run_aucell(
-        adata,
-        net=gene_set_gene,
-        source="gene_set",
-        target="gene",
-        use_raw=use_raw,
-        min_n=min_n_genes,
-    )
+    try:
+        dc.run_aucell(
+            adata,
+            net=gene_set_gene,
+            source="gene_set",
+            target="gene",
+            use_raw=use_raw,
+            min_n=min_n_genes,
+        )
+    except ValueError as ve:
+        print(f"Gene list {score_name} failed, skipping: {str(ve)}")
     for gs in gene_set_gene.gene_set.unique():
         if gs in adata.obsm["aucell_estimate"].keys():
             adata.obs[f"AUCell_{gs}"] = adata.obsm["aucell_estimate"][gs]

--- a/tools/tertiary-analysis/decoupler/decoupler_aucell_score.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_aucell_score.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="score_genes_aucell" name="Decoupler AUCell" version="1.4.0+galaxy3" profile="20.05">
+<tool id="score_genes_aucell" name="Decoupler AUCell" version="1.4.0+galaxy4" profile="20.05">
     <description>
         scores cells using the AUCell method for gene sets.
     </description>


### PR DESCRIPTION
# Description

For some reason the handling of failed datasets was deleted (by mistake) on #317 .

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [ ] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
