### PR TITLE
Decoupler: Error and explanation if contrasts and AnnData don't match

### DIFF
--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -515,13 +515,12 @@ condition2{os.linesep}")
 
         if len(failed_conditions) > 0:
             raise ValueError(
-                    f"Condition(s) '{failed_conditions}' "
-                    f"from contrast {contrast} "
-                    f"is/are not present in the "
-                    f"obs_field '{obs_field}' from the AnnData object."
-                    f"Possible values are: "
-                    f"{', '.join(adata.obs[obs_field].unique())}."
-                )
+                f"Condition(s) '{failed_conditions}' "
+                f"from contrast {contrast} "
+                f"is/are not present in the "
+                f"obs_field '{obs_field}' from the AnnData object."
+                f"Possible values are: "
+                f"{', '.join(adata.obs[obs_field].unique())}.")
         # we want to find the genes that are below the threshold
         # of % of cells expressed for ALL the conditions in the
         # contrast. It is enough for one of the conditions

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -503,6 +503,14 @@ condition2{os.linesep}")
         for condition in conditions:
             # remove any starting or trailing whitespaces from condition
             condition = condition.strip()
+            if condition not in adata.obs[obs_field].unique():
+                raise ValueError(
+                    f"Condition '{condition}' from contrast {contrast}"
+                    f" is not present in the "
+                    f"obs_field '{obs_field}' from the AnnData object."
+                    f"Possible values are: "
+                    f"{', '.join(adata.obs[obs_field].unique())}."
+                )
             # check the percentage of cells that express each gene
             # Filter the AnnData object based on the obs_field value
             adata_filtered = adata[adata.obs[obs_field] == condition]

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -462,7 +462,8 @@ def identify_genes_to_filter_per_contrast(
     >>> import os
     >>> from io import StringIO
     >>> contrast_file = StringIO(f"contrast{os.linesep}condition1-\
-condition2{os.linesep}")
+condition2{os.linesep}\
+2*(condition1)-condition2{os.linesep}")
     >>> min_perc_cells_expression = 30.0
     >>> data = {
     ...     'obs': pd.DataFrame({'condition': ['condition1', 'condition1',
@@ -476,9 +477,11 @@ condition2{os.linesep}")
     ... ) # doctest:+ELLIPSIS
     Identifying genes to filter using ...
     >>> df.head() # doctest:+ELLIPSIS
-                    contrast gene
-    0  condition1-condition2    ...
-    1  condition1-condition2    ...
+                        contrast gene
+    0      condition1-condition2...
+    1      condition1-condition2...
+    2  2*(condition1)-condition2...
+    3  2*(condition1)-condition2...
     """
     import re
 

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -1,4 +1,4 @@
-<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy6" profile="20.05">
+<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy7" profile="20.05">
     <description>aggregates single cell RNA-seq data for running bulk RNA-seq methods</description>
     <requirements>
         <requirement type="package" version="1.4.0">decoupler</requirement>

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -1,4 +1,4 @@
-<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy5" profile="20.05">
+<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy6" profile="20.05">
     <description>aggregates single cell RNA-seq data for running bulk RNA-seq methods</description>
     <requirements>
         <requirement type="package" version="1.4.0">decoupler</requirement>
@@ -103,10 +103,10 @@ python '$__tool_directory__/decoupler_pseudobulk.py' $input_file
         <data name="filter_by_expr_plot" format="png" label="${tool.name} on ${on_string}: Filter by Expression plot" from_work_dir="plots_output_dir/filter_by_expr.png">
             <filter>produce_plots</filter>
         </data>
-        <data name="genes_ignore_per_contrast_field" format="tabular" label="{tool.name} on ${on_string}: Genes to ignore by contrast field" from_work_dir="deseq_output_dir/genes_to_ignore_per_contrast_field.tsv">
+        <data name="genes_ignore_per_contrast_field" format="tabular" label="${tool.name} on ${on_string}: Genes to ignore by contrast field" from_work_dir="deseq_output_dir/genes_to_ignore_per_contrast_field.tsv">
             <filter>factor_fields</filter>
         </data>
-        <data name="genes_ignore_per_contrast" format="tabular" label="{tool.name} on ${on_string}: Genes to ignore by contrast" from_work_dir="plots_output_dir/genes_to_filter_by_contrast.tsv">
+        <data name="genes_ignore_per_contrast" format="tabular" label="${tool.name} on ${on_string}: Genes to ignore by contrast" from_work_dir="plots_output_dir/genes_to_filter_by_contrast.tsv">
             <filter>filter_per_contrast['filter'] == 'yes'</filter>
         </data>
     </outputs>


### PR DESCRIPTION
# Description

This adds an error when the contrasts given and the anndata provided to decoupler pseudo-bulk are not compatible (missing values).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [x] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
