### PR TITLE
PySCENIC: Use bioconda dependency now available

### DIFF
--- a/tools/tertiary-analysis/pyscenic/.shed.yml
+++ b/tools/tertiary-analysis/pyscenic/.shed.yml
@@ -2,6 +2,7 @@ categories:
  - Transcriptomics
  - RNA
  - Sequence Analysis
+ - Single Cell
 description: "PySCENIC scripts based on usage at https://pyscenic.readthedocs.io/"
 long_description: |
         pySCENIC is a lightning-fast python implementation of the SCENIC pipeline (Single-Cell rEgulatory Network Inference and Clustering) 

--- a/tools/tertiary-analysis/pyscenic/macros.xml
+++ b/tools/tertiary-analysis/pyscenic/macros.xml
@@ -2,9 +2,7 @@
     <token name="@TOOL_VERSION@">0.12.1</token>
     <xml name="requirements">
         <requirements>
-            <container type="docker">
-            aertslab/pyscenic:@TOOL_VERSION@
-        </container>
+            <requirement type="package" version="@TOOL_VERSION@">pyscenic</requirement>
         </requirements>
     </xml>
     <xml name="citations">

--- a/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_aucell.xml
@@ -1,4 +1,4 @@
-<tool id="pyscenic_aucell" name="PySCENIC AUCell" profile="21.09" version="@TOOL_VERSION@+galaxy0">
+<tool id="pyscenic_aucell" name="PySCENIC AUCell" profile="21.09" version="@TOOL_VERSION@+galaxy1">
     <description>calculates AUCell to find relevant regulons/gene sets</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_binarize_aucell.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_binarize_aucell.xml
@@ -1,4 +1,4 @@
-<tool id="pyscenic_binarize" name="PySCENIC Binarize AUCell" profile="21.09" version="@TOOL_VERSION@+galaxy0">
+<tool id="pyscenic_binarize" name="PySCENIC Binarize AUCell" profile="21.09" version="@TOOL_VERSION@+galaxy1">
     <description>defines AUCell thresholds and tags cells as passing it or not</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_ctx.xml
@@ -1,4 +1,4 @@
-<tool id="pyscenic_ctx" name="PySCENIC CTX" profile="21.09" version="@TOOL_VERSION@+galaxy0">
+<tool id="pyscenic_ctx" name="PySCENIC CTX" profile="21.09" version="@TOOL_VERSION@+galaxy1">
     <description>
         computes active regulons based on a gene regulatory network
     </description>

--- a/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
+++ b/tools/tertiary-analysis/pyscenic/pyscenic_grn.xml
@@ -1,4 +1,4 @@
-<tool id="pyscenic_grn" name="PySCENIC GRN" version="@TOOL_VERSION@+galaxy0" profile="21.09">
+<tool id="pyscenic_grn" name="PySCENIC GRN" version="@TOOL_VERSION@+galaxy1" profile="21.09">
     <description>infers gene regulatory networks</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
# Description

Moves pyscenic to use the bioconda package and container as dependency instead of the aerstlab container.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [x] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
