### PR TITLE
Pseudo-bulk: Pseudo replicate generation from samples

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -186,7 +186,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         r-version: ['release']
     steps:
     - uses: actions/checkout@v4

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -74,12 +74,14 @@ def create_pseudo_replicates(adata, sample_key, num_replicates, seed=None):
     adata.obs[new_sample_key] = adata.obs[sample_key].astype(str)
 
     for sample in adata.obs[sample_key].unique():
-        sample_indices = adata.obs[adata.obs[sample_key] == sample].index
+        sample_indices = adata.obs[
+            adata.obs[sample_key] == sample].index.copy()
+        np.random.shuffle(sample_indices)  # Shuffle the indices to randomize
+        replicate_size = int(len(sample_indices) / num_replicates)
         for i in range(num_replicates):
-            replicate_indices = np.random.choice(
-                sample_indices, size=int(len(sample_indices) / num_replicates),
-                replace=False
-            )
+            start_idx = i * replicate_size
+            end_idx = start_idx + replicate_size
+            replicate_indices = sample_indices[start_idx:end_idx]
             adata.obs.loc[replicate_indices, new_sample_key] = (
                 adata.obs.loc[replicate_indices, new_sample_key] + f"_rep{i+1}"
             )

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -2,6 +2,7 @@ import argparse
 
 import anndata
 import decoupler
+import numpy as np
 import pandas as pd
 
 
@@ -32,6 +33,55 @@ def get_pseudobulk(
         min_cells=min_cells,
         min_counts=min_counts,
     )
+
+
+def create_pseudo_replicates(adata, sample_key, num_replicates):
+    """
+    Create pseudo replicates for each sample in the sample_key groups.
+
+    Parameters
+    ----------
+    adata : anndata.AnnData
+        The AnnData object.
+    sample_key : str
+        The column in adata.obs that defines the samples.
+    num_replicates : int
+        Number of pseudo replicates to create per sample.
+
+    Returns
+    -------
+    anndata.AnnData
+        The AnnData object with pseudo replicates.
+
+    Examples
+    --------
+    >>> import anndata
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> data = {
+    ...     'obs': pd.DataFrame({'sample': ['A', 'A', 'B', 'B']}),
+    ...     'X': np.array([[1, 0], [0, 1], [1, 1], [0, 0]])
+    ... }
+    >>> adata = anndata.AnnData(X=data['X'], obs=data['obs'])
+    >>> adata = create_pseudo_replicates(adata, 'sample', 2)
+    >>> adata.obs['sample_pseudo'].tolist()
+    ['A_rep1', 'A_rep2', 'B_rep1', 'B_rep2']
+    """
+    new_sample_key = f"{sample_key}_pseudo"
+    adata.obs[new_sample_key] = adata.obs[sample_key].astype(str)
+
+    for sample in adata.obs[sample_key].unique():
+        sample_indices = adata.obs[adata.obs[sample_key] == sample].index
+        for i in range(num_replicates):
+            replicate_indices = np.random.choice(
+                sample_indices, size=int(len(sample_indices)/num_replicates),
+                replace=False
+            )
+            adata.obs.loc[replicate_indices, new_sample_key] = (
+                adata.obs.loc[replicate_indices, new_sample_key] + f"_rep{i+1}"
+            )
+
+    return adata
 
 
 def prepend_c_to_index(index_value):
@@ -306,6 +356,13 @@ def main(args):
     if args.factor_fields:
         factor_fields = args.factor_fields.split(",")
         check_fields(factor_fields, adata)
+
+    # Create pseudo replicates if specified
+    if args.num_pseudo_replicates:
+        adata = create_pseudo_replicates(
+            adata, args.sample_key, args.num_pseudo_replicates
+        )
+        args.sample_key = f"{args.sample_key}_pseudo"
 
     print(f"Using mode: {args.mode}")
     # Perform pseudobulk analysis
@@ -662,6 +719,13 @@ if __name__ == "__main__":
         "--min_total_counts",
         type=int,
         help="Minimum total count threshold for filtering by expression",
+    )
+    parser.add_argument(
+        "--num_pseudo_replicates",
+        type=int,
+        choices=range(3, 1000),
+        help="Number of pseudo replicates to create per sample (at least 3)",
+        required=False
     )
     parser.add_argument(
         "--anndata_output_path",

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -75,7 +75,7 @@ def create_pseudo_replicates(adata, sample_key, num_replicates, seed=None):
 
     for sample in adata.obs[sample_key].unique():
         sample_indices = adata.obs[
-            adata.obs[sample_key] == sample].index.copy()
+            adata.obs[sample_key] == sample].index.to_numpy()
         np.random.shuffle(sample_indices)  # Shuffle the indices to randomize
         replicate_size = int(len(sample_indices) / num_replicates)
         for i in range(num_replicates):

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -35,7 +35,7 @@ def get_pseudobulk(
     )
 
 
-def create_pseudo_replicates(adata, sample_key, num_replicates):
+def create_pseudo_replicates(adata, sample_key, num_replicates, seed=None):
     """
     Create pseudo replicates for each sample in the sample_key groups.
 
@@ -67,6 +67,9 @@ def create_pseudo_replicates(adata, sample_key, num_replicates):
     >>> adata.obs['sample_pseudo'].tolist()
     ['A_rep1', 'A_rep2', 'B_rep1', 'B_rep2']
     """
+    if seed is not None:
+        np.random.seed(seed)
+
     new_sample_key = f"{sample_key}_pseudo"
     adata.obs[new_sample_key] = adata.obs[sample_key].astype(str)
 
@@ -360,7 +363,7 @@ def main(args):
     # Create pseudo replicates if specified
     if args.num_pseudo_replicates:
         adata = create_pseudo_replicates(
-            adata, args.sample_key, args.num_pseudo_replicates
+            adata, args.sample_key, args.num_pseudo_replicates, seed=args.seed
         )
         args.sample_key = f"{args.sample_key}_pseudo"
 
@@ -726,6 +729,12 @@ if __name__ == "__main__":
         choices=range(3, 1000),
         help="Number of pseudo replicates to create per sample (at least 3)",
         required=False
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for pseudo replicate sampling",
     )
     parser.add_argument(
         "--anndata_output_path",

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -77,7 +77,7 @@ def create_pseudo_replicates(adata, sample_key, num_replicates, seed=None):
         sample_indices = adata.obs[adata.obs[sample_key] == sample].index
         for i in range(num_replicates):
             replicate_indices = np.random.choice(
-                sample_indices, size=int(len(sample_indices)/num_replicates),
+                sample_indices, size=int(len(sample_indices) / num_replicates),
                 replace=False
             )
             adata.obs.loc[replicate_indices, new_sample_key] = (

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -265,25 +265,25 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
             </output>
             <output name="count_matrix" ftype="tabular">
                 <assert_contents>
-                    <has_n_lines n="3544"/>
-                    <has_n_columns n="57"/>
+                    <has_n_lines n="3620"/>
+                    <has_n_columns n="22"/>
                 </assert_contents>
             </output>
             <output name="samples_metadata" ftype="tabular">
                 <assert_contents>
-                    <has_n_lines n="57"/>
+                    <has_n_lines n="22"/>
                     <has_n_columns n="3"/>
                 </assert_contents>
             </output>
             <output name="genes_metadata" ftype="tabular">
                 <assert_contents>
-                    <has_n_lines n="3544"/>
+                    <has_n_lines n="3620"/>
                     <has_n_columns n="13"/>
                 </assert_contents>
             </output>
             <output name="plot_output" ftype="png">
                 <assert_contents>
-                    <has_size value="42691" delta="3000"/>
+                    <has_size value="34626" delta="6000"/>
                 </assert_contents>
             </output>
             <output name="filter_by_expr_plot" ftype="png">

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -1,4 +1,4 @@
-<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy8" profile="20.05">
+<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy9" profile="20.05">
     <description>aggregates single cell RNA-seq data for running bulk RNA-seq methods</description>
     <requirements>
         <requirement type="package" version="1.4.0">decoupler</requirement>
@@ -47,6 +47,9 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
     --contrasts_file '$filter_per_contrast.contrasts_file'
     --min_gene_exp_perc_per_cell '$filter_per_contrast.min_cells_perc_per_contrast_cond'
     #end if
+    #if $num_pseudo_replicates:
+    --num_pseudo_replicates $num_pseudo_replicates
+    #end if
     --deseq2_output_path deseq_output_dir
     --plot_samples_figsize $plot_samples_figsize
     --plot_filtering_figsize $plot_filtering_figsize
@@ -89,6 +92,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
         <param type="boolean" name="filter_expr" label="Enable Filtering by Expression"/>
         <param type="text" name="plot_samples_figsize" label="Plot Samples Figsize" value="10 10" help="X and Y sizes in points separated by a space"/>
         <param type="text" name="plot_filtering_figsize" label="Plot Filtering Figsize" value="10 10" help="X and Y sizes in points separated by a space"/>
+        <param type="integer" name="num_pseudo_replicates" label="Number of Pseudo Replicates" optional="true" help="Number of pseudo replicates to create per sample (at least 3)" min="3" max="1000"/>
     </inputs>
     <outputs>
         <data name="pbulk_anndata" format="h5ad" label="${tool.name} on ${on_string}: Pseudo-bulk AnnData">
@@ -229,6 +233,65 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
                 </assert_contents>
             </output>
         </test>
+        <test expect_num_outputs="8">
+            <param name="input_file" value="mito_counted_anndata.h5ad"/>
+            <param name="filter" value="yes"/>
+            <param name="contrasts_file" value="test_contrasts.txt" ftype="txt"/>
+            <param name="min_cells_perc_per_contrast_cond" value="25"/>
+            <param name="adata_obs_fields_to_merge" value="batch,sex:batch,genotype"/>
+            <param name="groupby" value="batch_sex"/>
+            <param name="sample_key" value="genotype"/>
+            <param name="factor_fields" value="genotype,batch_sex"/>
+            <param name="mode" value="sum"/>
+            <param name="min_cells" value="10"/>
+            <param name="produce_plots" value="true"/>
+            <param name="produce_anndata" value="true"/>
+            <param name="min_counts" value="10"/>
+            <param name="min_counts_per_sample" value="50"/>
+            <param name="min_total_counts" value="1000"/>
+            <param name="filter_expr" value="true"/>
+            <param name="plot_samples_figsize" value="10 10"/>
+            <param name="plot_filtering_figsize" value="10 10"/>
+            <param name="num_pseudo_replicates" value="3"/>
+            <output name="pbulk_anndata" ftype="h5ad">
+                <assert_contents>
+                    <has_h5_keys keys="obs/psbulk_n_cells"/>
+                </assert_contents>
+            </output>
+            <output name="count_matrix" ftype="tabular">
+                <assert_contents>
+                    <has_n_lines n="3570"/>
+                    <has_n_columns n="24"/>
+                </assert_contents>
+            </output>
+            <output name="samples_metadata" ftype="tabular">
+                <assert_contents>
+                    <has_n_lines n="57"/>
+                    <has_n_columns n="3"/>
+                </assert_contents>
+            </output>
+            <output name="genes_metadata" ftype="tabular">
+                <assert_contents>
+                    <has_n_lines n="3570"/>
+                    <has_n_columns n="13"/>
+                </assert_contents>
+            </output>
+            <output name="plot_output" ftype="png">
+                <assert_contents>
+                    <has_size value="42691" delta="3000"/>
+                </assert_contents>
+            </output>
+            <output name="filter_by_expr_plot" ftype="png">
+                <assert_contents>
+                    <has_size value="21656" delta="2000"/>
+                </assert_contents>
+            </output>
+            <output name="genes_ignore_per_contrast" ftype="tabular">
+                <assert_contents>
+                    <has_n_lines n="35478"/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help>
         <![CDATA[
@@ -250,6 +313,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
         - Enable Filtering by Expression: Check this box to enable filtering by expression.
         - Plot Samples Figsize: Size of the samples plot as a tuple (two arguments).
         - Plot Filtering Figsize: Size of the filtering plot as a tuple (two arguments).
+        - Number of Pseudo Replicates: Number of pseudo replicates to create per sample (at least 3).
 
         The tool will output the filtered AnnData, count matrix, samples metadata, genes metadata (in DESeq2 format), and the pseudobulk plot and filter by expression plot (if enabled). Files for filtering genes later on are also generated (to ignore after the DE model).
 

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -266,7 +266,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
             <output name="count_matrix" ftype="tabular">
                 <assert_contents>
                     <has_n_lines n="3544"/>
-                    <has_n_columns n="24"/>
+                    <has_n_columns n="57"/>
                 </assert_contents>
             </output>
             <output name="samples_metadata" ftype="tabular">

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -49,6 +49,9 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
     #end if
     #if $num_pseudo_replicates:
     --num_pseudo_replicates $num_pseudo_replicates
+        #if $seed:
+        --seed '$seed'
+        #end if
     #end if
     --deseq2_output_path deseq_output_dir
     --plot_samples_figsize $plot_samples_figsize
@@ -92,7 +95,8 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
         <param type="boolean" name="filter_expr" label="Enable Filtering by Expression"/>
         <param type="text" name="plot_samples_figsize" label="Plot Samples Figsize" value="10 10" help="X and Y sizes in points separated by a space"/>
         <param type="text" name="plot_filtering_figsize" label="Plot Filtering Figsize" value="10 10" help="X and Y sizes in points separated by a space"/>
-        <param type="integer" name="num_pseudo_replicates" label="Number of Pseudo Replicates" optional="true" help="Number of pseudo replicates to create per sample (at least 3)" min="3" max="1000"/>
+        <param type="integer" name="num_pseudo_replicates" label="Number of Pseudo Replicates" optional="true" help="If set, create this number of pseudo replicates to create per sample (at least 3). If not set, there is an expectation that samples and groups are distributed in a way that (pseudo) replicates exists." min="3" max="1000"/>
+        <param type="integer" name="seed" label="Seed" optional="true" help="Seed for the random number generator used for sampling the pseudo replicates (only used if Number of Pseudo replicates set)."/>
     </inputs>
     <outputs>
         <data name="pbulk_anndata" format="h5ad" label="${tool.name} on ${on_string}: Pseudo-bulk AnnData">
@@ -253,6 +257,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
             <param name="plot_samples_figsize" value="10 10"/>
             <param name="plot_filtering_figsize" value="10 10"/>
             <param name="num_pseudo_replicates" value="3"/>
+            <param name="seed" value="42"/>
             <output name="pbulk_anndata" ftype="h5ad">
                 <assert_contents>
                     <has_h5_keys keys="obs/psbulk_n_cells"/>
@@ -260,7 +265,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
             </output>
             <output name="count_matrix" ftype="tabular">
                 <assert_contents>
-                    <has_n_lines n="3570"/>
+                    <has_n_lines n="3544"/>
                     <has_n_columns n="24"/>
                 </assert_contents>
             </output>
@@ -272,7 +277,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
             </output>
             <output name="genes_metadata" ftype="tabular">
                 <assert_contents>
-                    <has_n_lines n="3570"/>
+                    <has_n_lines n="3544"/>
                     <has_n_columns n="13"/>
                 </assert_contents>
             </output>


### PR DESCRIPTION
# Description

This adds the ability to automatically generate pseudo-replicates by sampling cells (size of sample / num of replicates) from each sample group.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
