### PR TITLE
Feature/decoupler ncells fields output

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -372,7 +372,7 @@ jobs:
   # deploy the tools to the toolsheds (first TTS for testing)
   deploy:
     name: Deploy
-    needs: [setup, lint, combine_outputs]
+    needs: [setup, combine_outputs]
     if: ${{ github.ref == 'refs/heads/main' && github.repository_owner == 'ebi-gene-expression-group' }}
     runs-on: ubuntu-latest
     strategy:

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -328,8 +328,8 @@ def check_fields(fields, adata, obs=True, context=None):
     pseudobulk_generated_fields = ['psbulk_n_cells', 'psbulk_counts']
 
     # Filter out the pseudobulk-generated fields from checking
-    fields_to_check = [field for field in fields 
-                      if field not in pseudobulk_generated_fields]
+    fields_to_check = [field for field in fields
+                       if field not in pseudobulk_generated_fields]
 
     legend = ""
     if context:

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -324,18 +324,24 @@ def check_fields(fields, adata, obs=True, context=None):
     >>> check_fields(["bulk_labels", "louvain"], adata, obs=True)
     """
 
+    # Fields that will be created during the pseudobulking process
+    pseudobulk_generated_fields = ['psbulk_n_cells', 'psbulk_counts']
+    
+    # Filter out the pseudobulk-generated fields from checking
+    fields_to_check = [field for field in fields if field not in pseudobulk_generated_fields]
+    
     legend = ""
     if context:
         legend = f", passed in {context},"
     if obs:
-        if not set(fields).issubset(set(adata.obs.columns)):
+        if not set(fields_to_check).issubset(set(adata.obs.columns)):
             raise ValueError(
                 f"Some of the following fields {legend} are not present \
                     in adata.obs: {fields}. \
                         Possible fields are: {list(set(adata.obs.columns))}"
             )
     else:
-        if not set(fields).issubset(set(adata.var.columns)):
+        if not set(fields_to_check).issubset(set(adata.var.columns)):
             raise ValueError(
                 f"Some of the following fields {legend} are not present \
                     in adata.var: {fields}. \

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -337,14 +337,14 @@ def check_fields(fields, adata, obs=True, context=None):
         if not set(fields_to_check).issubset(set(adata.obs.columns)):
             raise ValueError(
                 f"Some of the following fields {legend} are not present \
-                    in adata.obs: {fields}. \
+                    in adata.obs: {fields_to_check}. \
                         Possible fields are: {list(set(adata.obs.columns))}"
             )
     else:
         if not set(fields_to_check).issubset(set(adata.var.columns)):
             raise ValueError(
                 f"Some of the following fields {legend} are not present \
-                    in adata.var: {fields}. \
+                    in adata.var: {fields_to_check}. \
                         Possible fields are: {list(set(adata.var.columns))}"
             )
 

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.py
@@ -326,10 +326,11 @@ def check_fields(fields, adata, obs=True, context=None):
 
     # Fields that will be created during the pseudobulking process
     pseudobulk_generated_fields = ['psbulk_n_cells', 'psbulk_counts']
-    
+
     # Filter out the pseudobulk-generated fields from checking
-    fields_to_check = [field for field in fields if field not in pseudobulk_generated_fields]
-    
+    fields_to_check = [field for field in fields 
+                      if field not in pseudobulk_generated_fields]
+
     legend = ""
     if context:
         legend = f", passed in {context},"

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -1,4 +1,4 @@
-<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy9" profile="20.05">
+<tool id="decoupler_pseudobulk" name="Decoupler pseudo-bulk" version="1.4.0+galaxy10" profile="20.05">
     <description>aggregates single cell RNA-seq data for running bulk RNA-seq methods</description>
     <requirements>
         <requirement type="package" version="1.4.0">decoupler</requirement>
@@ -245,7 +245,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
             <param name="adata_obs_fields_to_merge" value="batch,sex:batch,genotype"/>
             <param name="groupby" value="batch_sex"/>
             <param name="sample_key" value="genotype"/>
-            <param name="factor_fields" value="genotype,batch_sex"/>
+            <param name="factor_fields" value="genotype,batch_sex,psbulk_n_cells"/>
             <param name="mode" value="sum"/>
             <param name="min_cells" value="10"/>
             <param name="produce_plots" value="true"/>
@@ -323,6 +323,8 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
         The tool will output the filtered AnnData, count matrix, samples metadata, genes metadata (in DESeq2 format), and the pseudobulk plot and filter by expression plot (if enabled). Files for filtering genes later on are also generated (to ignore after the DE model).
 
         You can obtain more information about Decoupler pseudobulk at the developers documentation `here <https://decoupler-py.readthedocs.io/en/latest/notebooks/pseudobulk.html>`_ .
+
+        1.4.0+galaxy10: Fixes ability to pass psbulk metadata fields downstream.
 
         ]]>
     </help>

--- a/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
+++ b/tools/tertiary-analysis/decoupler/decoupler_pseudobulk.xml
@@ -272,7 +272,7 @@ python '$__tool_directory__/decoupler_pseudobulk.py' '$input_file'
             <output name="samples_metadata" ftype="tabular">
                 <assert_contents>
                     <has_n_lines n="22"/>
-                    <has_n_columns n="3"/>
+                    <has_n_columns n="4"/>
                 </assert_contents>
             </output>
             <output name="genes_metadata" ftype="tabular">


### PR DESCRIPTION
# Description

Redoing PR #346  as it should be merged after #344 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have made any required changes to upstream dependencies for a tool wrapper, and they are available in distribution channels (e.g. Pip, Conda).
- [ ] If I have updated the underlying software for a tool wrapper (e.g. scanpy-scripts by changing the value of `@TOOL_VERSION@`), then I have reset all 'build' values to 0 (e.g. `@TOOL_VERSION@+galaxy0`)
- [x] If I have updated a tool wrapper without a software change, then I have bumped the associated 'build' values (e.g. `@TOOL_VERSION@+galaxy0` `@TOOL_VERSION@+galaxy1`). It is acceptable to do this as well when the cli version changed but not the underlying tool (to avoid issues in the coming point).
- [ ] If I changed the version, the `@TOOL_VERSION@` part of the version does not contain any `+` symbols within, otherwise this will break tool ordering on the interface and the default tool being picked. Tool version should always conform to [PEP440](https://peps.python.org/pep-0440/) to avoid [this issue](https://github.com/galaxyproject/galaxy/issues/15071). The only `+` should be the one preceding `galaxy<build>` (unless that all the versions from that tool previously followed a different pattern).  
